### PR TITLE
feat(security): add CSP meta tags & gate keep secrets out of the client bundle

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -25,6 +25,35 @@ describe('config', () => {
     })
   })
 
+  describe('GITHUB_KEY', () => {
+    it('exposes the token to server-side code', async () => {
+      vi.stubEnv('SSR', true)
+      vi.stubEnv('VITE_GITHUB_KEY', 'token ghp_test')
+      vi.resetModules()
+      const { GITHUB_KEY } = await import('./config')
+      expect(GITHUB_KEY).toBe('token ghp_test')
+    })
+
+    it('falls back to empty string when VITE_GITHUB_KEY is not defined', async () => {
+      vi.stubEnv('SSR', true)
+      const env = import.meta.env as Record<string, unknown>
+      const saved = env.VITE_GITHUB_KEY
+      delete env.VITE_GITHUB_KEY
+      vi.resetModules()
+      const { GITHUB_KEY } = await import('./config')
+      expect(GITHUB_KEY).toBe('')
+      env.VITE_GITHUB_KEY = saved
+    })
+
+    it('is empty in the client bundle so the token can never ship to visitors', async () => {
+      vi.stubEnv('SSR', false)
+      vi.stubEnv('VITE_GITHUB_KEY', 'token ghp_test')
+      vi.resetModules()
+      const { GITHUB_KEY } = await import('./config')
+      expect(GITHUB_KEY).toBe('')
+    })
+  })
+
   describe('STORYBOOK_URL', () => {
     it('uses VITE_STORYBOOK_URL when defined', async () => {
       vi.stubEnv('VITE_STORYBOOK_URL', 'http://localhost:6006')

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 export const BASE_URL = import.meta.env.VITE_BASE_URL ?? ''
 export const SITE_URL = import.meta.env.VITE_SITE_URL ?? 'https://soroush.tech'
-export const GITHUB_KEY = import.meta.env.VITE_GITHUB_KEY ?? ''
+// SSR-only: `import.meta.env.SSR` is statically false in the client build, so the
+// token literal is constant-folded away and can never ship to visitors.
+export const GITHUB_KEY = import.meta.env.SSR ? (import.meta.env.VITE_GITHUB_KEY ?? '') : ''
 export const REQUEST_TIMEOUT = import.meta.env.VITE_REQUEST_TIMEOUT ?? 5000
 export const MSW_ACTIVE = import.meta.env.VITE_APP_MSW_ACTIVE === 'true'
 export const STORYBOOK_URL = import.meta.env.VITE_STORYBOOK_URL ?? ''

--- a/src/renderer/buildHead.test.ts
+++ b/src/renderer/buildHead.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import type { PageContext } from 'vike/types'
 import { buildHead } from './buildHead'
 
@@ -92,6 +92,33 @@ describe('buildHead', () => {
       )
       expect(minimal).not.toContain('article:published_time')
       expect(minimal).not.toContain('"author"')
+    })
+  })
+
+  describe('security tags', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs()
+    })
+
+    it('always emits the referrer policy', () => {
+      expect(buildHead(ctx())).toContain(
+        '<meta name="referrer" content="strict-origin-when-cross-origin" />'
+      )
+    })
+
+    it('omits the CSP in dev (inline HMR scripts would be blocked)', () => {
+      expect(buildHead(ctx())).not.toContain('Content-Security-Policy')
+    })
+
+    it('emits the CSP outside dev', () => {
+      vi.stubEnv('DEV', false)
+      const head = buildHead(ctx())
+      expect(head).toContain('<meta http-equiv="Content-Security-Policy" content="')
+      expect(head).toContain("default-src 'self'")
+      expect(head).toContain("script-src 'self'")
+      expect(head).toContain("style-src 'self' 'unsafe-inline'")
+      expect(head).toContain("img-src 'self' https://*.githubusercontent.com data:")
+      expect(head).toContain("connect-src 'self' https://api.github.com")
     })
   })
 

--- a/src/renderer/buildHead.ts
+++ b/src/renderer/buildHead.ts
@@ -15,6 +15,19 @@ const escape = (value: string): string =>
 const isArticleMeta = (data: unknown): data is PageMeta =>
   typeof data === 'object' && data !== null && 'title' in data
 
+// 'unsafe-inline' styles are required by Emotion's critical-CSS extraction;
+// *.githubusercontent.com covers avatars and gist-proxied images.
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' https://*.githubusercontent.com data:",
+  "connect-src 'self' https://api.github.com",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join('; ')
+
 const jsonLd = (meta: PageMeta, url: string): string => {
   const schema = {
     '@context': 'https://schema.org',
@@ -43,6 +56,11 @@ export const buildHead = (pageContext: PageContext): string => {
 
   const tags = [
     `<title>${escape(documentTitle(pageContext))}</title>`,
+    // Dev is skipped: Vite/React-refresh inject inline scripts that `script-src 'self'` would block.
+    ...(import.meta.env.DEV
+      ? []
+      : [`<meta http-equiv="Content-Security-Policy" content="${CSP}" />`]),
+    `<meta name="referrer" content="strict-origin-when-cross-origin" />`,
     `<link rel="canonical" href="${escape(url)}" />`,
     `<meta name="robots" content="${escape(robots)}" />`,
     `<meta property="og:type" content="${article ? 'article' : 'website'}" />`,


### PR DESCRIPTION
add CSP meta tags & gate keep secrets out of the client bundle

  - buildHead: emit a Content-Security-Policy meta tag (self-only scripts, Emotion inline styles, githubusercontent images, GitHub API connects) on production builds — skipped in dev where HMR injects inline scripts — plus an explicit strict-origin-when-cross-origin referrer policy
  - config: gate GITHUB_KEY behind import.meta.env.SSR so the token is constant-folded out of the client build and can never ship to visitors,while prerender keeps it for API rate limits
  - verified: dummy token build → 0 hits in build/client; e2e suite passes against the production build with the CSP enforced