### PR TITLE
feat: SEO metadata system, local-env onboarding, and contact hardening 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ dist
 dist-ssr
 *.local
 .env
+.env.local
 prod.env
 
 # Local issue drafts

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # soroush.tech
 
-**Personal website of Masoud Soroush**  
+**Personal portfolio of Masoud Soroush**  
 [https://soroush.tech](https://soroush.tech)
 
 This repository is my digital home — a place to share article posts, showcase my
@@ -12,6 +12,26 @@ systems, and anything else worth sharing as I grow and learn.
 
 It is organized as a **pnpm workspace monorepo**: the website is one app among
 its own shared tooling packages and (soon) backend workers.
+
+## 🚀 Getting started
+
+### Prerequisites
+
+- **Node 25** — pinned in [`.nvmrc`](./.nvmrc) (`nvm use`).
+- **pnpm 10.13.1** — pinned via the `packageManager` field.
+
+### Install & run
+
+```bash
+pnpm install   # installs every workspace (also runs the setup below)
+pnpm prepare   # set up all you need — git hooks + per-workspace local env
+pnpm dev       # starts the web app dev server
+```
+
+`pnpm prepare` runs husky and then each workspace's `setup` (`pnpm -r run setup`):
+it bootstraps `apps/web/.env.local` and `workers/api/.env` from their `default.env`
+templates (never overwriting an existing file, skipped in CI). It runs automatically
+on `pnpm install`; re-run it any time with `pnpm prepare` (or `pnpm run setup`).
 
 ---
 
@@ -58,27 +78,6 @@ Globs live in [`pnpm-workspace.yaml`](./pnpm-workspace.yaml) (`apps/*`,
 **SEO** is handled at build time: `@soroush.tech/vite-plugin-sitemap` emits
 `sitemap.xml` from the prerendered HTML (skipping `noindex` pages), and a
 static `robots.txt` ships from `apps/web/public/`.
-
----
-
-## 🚀 Getting started
-
-### Prerequisites
-
-- **Node 25** — pinned in [`.nvmrc`](./.nvmrc) (`nvm use`).
-- **pnpm 10.13.1** — pinned via the `packageManager` field.
-
-### Install & run
-
-```bash
-pnpm install   # installs every workspace
-pnpm dev       # starts the web app dev server
-```
-
-Top-level scripts proxy into `apps/web` (e.g. `pnpm dev`, `pnpm build`,
-`pnpm test`, `pnpm deploy`), while `pnpm lint` and `pnpm typecheck` run
-**recursively across all workspaces** (`pnpm -r`). For app-specific scripts and
-structure, see [apps/web/README.md](./apps/web/README.md).
 
 ---
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -30,6 +30,10 @@ pnpm install   # from the repo root
 pnpm dev       # start the Vite dev server
 ```
 
+`pnpm install` bootstraps `apps/web/.env.local` from [`default.env`](./default.env) (via the
+root `postprepare` → `pnpm run setup`) so Vite has its `VITE_*` values — it never overwrites an
+existing file. Edit `.env.local` for your local secrets, or re-run `pnpm run setup`.
+
 ---
 
 ## 📁 Structure

--- a/apps/web/default.env
+++ b/apps/web/default.env
@@ -1,4 +1,4 @@
-VITE_BASE_URL=https://api.soroush.tech/v1/
+VITE_BASE_URL=https://api.github.com
 VITE_API_KEY=
 # soroush.tech Worker API base (contact form). Local dev points at `wrangler dev`.
 VITE_API_URL=http://localhost:8787/v1

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "license": "Custom -> SEE LICENSE file",
   "scripts": {
     "dev": "vite",
+    "setup": "node scripts/setup-env.mjs",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx --report-unused-disable-directives --cache --max-warnings 0",
     "git:refresh": "git update-index -q --refresh",
     "gen:experienceGraph": "node scripts/gen-experienceGraph.ts",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,7 +40,7 @@
     "build:compress": "cross-env COMPRESS=true pnpm build",
     "build:storybook": "cross-env NODE_ENV=storybook storybook build",
     "preview": "vite preview",
-    "preview:e2e": "serve build/client -l 3000",
+    "preview:e2e": "serve build/client -l 9999",
     "preview:storybook": "npx serve storybook-static",
     "deploy": "gh-pages -d build"
   },

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : 2,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:9999',
     trace: 'on-first-retry',
     headless: true,
   },
@@ -38,13 +38,19 @@ export default defineConfig({
     },
   ],
   webServer: {
+    // Dedicated e2e port (via E2E_PORT below) so we never reuse a developer's
+    // `pnpm dev` on 3000 (MSW off) — that server lacks VITE_APP_MSW_ACTIVE and
+    // the mocks never load. The port is applied in vite.config.ts.
     command: coverage ? 'pnpm build && pnpm preview:e2e' : 'pnpm dev',
-    port: 3000,
+    port: 9999,
     // Never reuse a running dev server for coverage — it must hit the sourcemapped build.
     reuseExistingServer: coverage ? false : !process.env.CI,
     timeout: coverage ? 180_000 : 60_000,
     // Mock server-side GitHub fetches for e2e (dev SSR + prerender) via the gated
     // msw/node vite plugin and the browser worker. Never set by CD's build.
-    env: { ...process.env, VITE_APP_MSW_ACTIVE: 'true' } as Record<string, string>,
+    env: { ...process.env, VITE_APP_MSW_ACTIVE: 'true', E2E_PORT: '9999' } as Record<
+      string,
+      string
+    >,
   },
 })

--- a/apps/web/scripts/setup-env.mjs
+++ b/apps/web/scripts/setup-env.mjs
@@ -1,0 +1,21 @@
+import { copyFileSync, existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Bootstrap the local env: copy default.env -> .env.local on first setup. Vite loads .env.local
+// (not default.env), so without this a fresh clone runs with empty VITE_* and the API calls fail.
+const dir = dirname(fileURLToPath(import.meta.url))
+const template = resolve(dir, '../default.env')
+const target = resolve(dir, '../.env.local')
+
+if (process.env.CI) {
+  // CD injects VITE_* via ambient env (cd-web.yml); a generated .env.local must never appear in CI.
+  console.log('setup-env: CI detected — skipping apps/web/.env.local')
+} else if (!existsSync(template)) {
+  console.log('setup-env: no apps/web/default.env template — nothing to copy')
+} else if (existsSync(target)) {
+  console.log('setup-env: apps/web/.env.local already exists — leaving it untouched')
+} else {
+  copyFileSync(template, target)
+  console.log('setup-env: created apps/web/.env.local from default.env')
+}

--- a/apps/web/src/common/Logo/Logo.tsx
+++ b/apps/web/src/common/Logo/Logo.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import LogoSvg from '/soroush.svg'
+import LogoSvg from 'src/assets/soroush.svg'
 
 interface LogoProps {
   size?: number

--- a/apps/web/src/hooks/useContactSubmit.ts
+++ b/apps/web/src/hooks/useContactSubmit.ts
@@ -7,12 +7,18 @@ export interface ContactSubmitPayload extends ContactFormValues {
   turnstileToken: string
 }
 
+/** Worker response: `ok` plus the stored submission `id` used to show a reference to the user. */
+export interface ContactSubmitResponse {
+  ok: boolean
+  id: string
+}
+
 /**
  * Submits a validated contact form to the Worker `POST /contact` endpoint via the dedicated API
  * client (`VITE_API_URL`). The axios client rejects on a non-2xx response, surfacing as `isError`.
  */
 export function useContactSubmit() {
-  return useCustomMutation<unknown, ContactSubmitPayload>({
+  return useCustomMutation<ContactSubmitResponse, ContactSubmitPayload>({
     config: { url: '/contact', method: 'post' },
     client: apiClient,
   })

--- a/apps/web/src/pages/about/+config.ts
+++ b/apps/web/src/pages/about/+config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'vike/types'
 
 export default {
-  title: 'About Masoud',
+  title: 'About Masoud Soroush',
   description:
-    'Principal software engineer — Masoud Soroush core values, methodology, tech stack, and experience building high-performance, resilient systems.',
+    'Principal software engineer — Masoud Soroush core values, tech stack: Web (react, next.js), Mobile (react-native),  Desktop (Electron), Backend (Node.js, Nest.js, Hono, Fastify), Dev-ops (AWS, GCP, Docker, Kubernetes, CI/CD) and experience building event-driven, high-performance, System Design, resilient systems.',
 } satisfies Config

--- a/apps/web/src/pages/about/+data.test.ts
+++ b/apps/web/src/pages/about/+data.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import type { PageContext } from 'vike/types'
+import { data } from './+data'
+
+describe('data', () => {
+  it('returns social meta sourced from config, with the page image', () => {
+    const result = data({ config: { title: 'About', description: 'D' } } as unknown as PageContext)
+    expect(result.meta).toContainEqual({ property: 'og:title', content: 'About' })
+    expect(result.meta).toContainEqual({
+      property: 'og:image',
+      content: 'https://soroush.tech/mock.png',
+    })
+  })
+})

--- a/apps/web/src/pages/about/+data.ts
+++ b/apps/web/src/pages/about/+data.ts
@@ -1,0 +1,8 @@
+import type { PageContext } from 'vike/types'
+// +data runs in the normal Vite pipeline, so it can import imagetools assets (unlike +config).
+import portrait from 'src/assets/masoud_soroush.png?w=1200&format=png&as=picture'
+import { pageSocialMeta, type HeadMeta } from 'src/renderer/head'
+
+export function data(pageContext: PageContext): HeadMeta {
+  return { meta: pageSocialMeta(pageContext, portrait) }
+}

--- a/apps/web/src/pages/article/@id/+data.test.ts
+++ b/apps/web/src/pages/article/@id/+data.test.ts
@@ -7,7 +7,7 @@ import queryClient from 'src/utils/api/queryClient'
 import { data } from './+data'
 
 describe('data', () => {
-  it('prefetches the gist into the query cache and returns its SEO meta', async () => {
+  it('prefetches the gist and returns its head meta + article tags + JSON-LD', async () => {
     const gist = {
       id: 'abc123',
       description: 'a gist',
@@ -17,26 +17,44 @@ describe('data', () => {
     }
     server.use(http.get(`${BASE_URL}/gists/abc123`, () => HttpResponse.json(gist)))
 
-    const meta = await data({ routeParams: { id: 'abc123' } } as unknown as PageContext)
+    const result = await data({ routeParams: { id: 'abc123' } } as unknown as PageContext)
 
     expect(queryClient.getQueryData(['gist', 'abc123'])).toEqual(gist)
-    expect(meta).toEqual({
-      title: 'a gist',
-      description: 'a gist',
-      publishedTime: '2021-03-15T10:00:00Z',
-      modifiedTime: '2021-04-01T10:00:00Z',
-      author: 'Masoud Soroush',
+    // title/description are consumed by the +title and +description hooks.
+    expect(result.title).toBe('a gist')
+    expect(result.description).toBe('a gist')
+    expect(result.meta).toContainEqual({ property: 'og:type', content: 'article' })
+    expect(result.meta).toContainEqual({
+      property: 'article:published_time',
+      content: '2021-03-15T10:00:00Z',
+    })
+    expect(result.meta).toContainEqual({
+      property: 'article:modified_time',
+      content: '2021-04-01T10:00:00Z',
+    })
+    expect(result.meta).toContainEqual({ property: 'article:author', content: 'Masoud Soroush' })
+    expect(result.jsonLd).toMatchObject({
+      '@type': 'BlogPosting',
+      headline: 'a gist',
+      datePublished: '2021-03-15T10:00:00Z',
+      dateModified: '2021-04-01T10:00:00Z',
+      author: { '@type': 'Person', name: 'Masoud Soroush' },
+      mainEntityOfPage: 'https://soroush.tech/article/abc123/',
     })
   })
 
-  it('falls back to a default title when the gist has no description', async () => {
+  it('falls back to a default title and omits absent article fields', async () => {
     const gist = { id: 'noDesc', description: '', files: {} }
     server.use(http.get(`${BASE_URL}/gists/noDesc`, () => HttpResponse.json(gist)))
 
-    const meta = await data({ routeParams: { id: 'noDesc' } } as unknown as PageContext)
+    const result = await data({ routeParams: { id: 'noDesc' } } as unknown as PageContext)
 
-    expect(meta.title).toBe('Article')
-    expect(meta.description).toBe('')
-    expect(meta.author).toBeUndefined()
+    expect(result.title).toBe('Article')
+    expect(result.description).toBe('')
+    const keys = result.meta?.map((t) => ('name' in t ? t.name : t.property)) ?? []
+    expect(keys).not.toContain('article:published_time')
+    expect(keys).not.toContain('article:modified_time')
+    expect(keys).not.toContain('article:author')
+    expect(result.jsonLd).toMatchObject({ author: undefined })
   })
 })

--- a/apps/web/src/pages/article/@id/+data.ts
+++ b/apps/web/src/pages/article/@id/+data.ts
@@ -1,27 +1,45 @@
 import type { PageContext } from 'vike/types'
+import { SITE_URL } from 'src/config'
 import { prefetchGistById } from 'src/hooks/useGistById'
 import queryClient from 'src/utils/api/queryClient'
 import { authorName } from 'src/utils/authorName'
 import type { Gist } from 'src/types/github'
+import { socialMeta, type HeadMeta, type MetaTag } from 'src/renderer/head'
 
-export interface PageMeta {
-  title: string
-  description: string
-  publishedTime?: string
-  modifiedTime?: string
-  author?: string
-}
-
-export async function data(pageContext: PageContext): Promise<PageMeta> {
+export async function data(pageContext: PageContext): Promise<HeadMeta> {
   const { id } = pageContext.routeParams
   await prefetchGistById(id)
   const gist = queryClient.getQueryData<Gist>(['gist', id])
 
+  const title = gist?.description || 'Article'
+  const description = gist?.description || ''
+  const publishedTime = gist?.created_at
+  const modifiedTime = gist?.updated_at
+  const author = gist?.owner?.login ? authorName(gist.owner.login) : undefined
+  // Trailing slash matches the canonical URL buildHead derives from the path.
+  const url = `${SITE_URL}/article/${id}/`
+
+  const articleTags: MetaTag[] = []
+  if (publishedTime)
+    articleTags.push({ property: 'article:published_time', content: publishedTime })
+  // The sitemap plugin reads article:modified_time from the built HTML for <lastmod>.
+  if (modifiedTime) articleTags.push({ property: 'article:modified_time', content: modifiedTime })
+  if (author) articleTags.push({ property: 'article:author', content: author })
+
   return {
-    title: gist?.description || 'Article',
-    description: gist?.description || '',
-    publishedTime: gist?.created_at,
-    modifiedTime: gist?.updated_at,
-    author: gist?.owner?.login ? authorName(gist.owner.login) : undefined,
+    // title/description are also read by the +title and +description hooks.
+    title,
+    description,
+    meta: [...socialMeta({ title, description, type: 'article' }), ...articleTags],
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      headline: title,
+      description,
+      datePublished: publishedTime,
+      dateModified: modifiedTime,
+      author: author ? { '@type': 'Person', name: author } : undefined,
+      mainEntityOfPage: url,
+    },
   }
 }

--- a/apps/web/src/pages/article/@id/+description.ts
+++ b/apps/web/src/pages/article/@id/+description.ts
@@ -1,5 +1,5 @@
 import type { PageContext } from 'vike/types'
-import type { PageMeta } from './+data'
+import type { HeadMeta } from 'src/renderer/head'
 
 export default (pageContext: PageContext): string =>
-  ((pageContext.data as PageMeta | undefined)?.description ?? '') + ' - Masoud Soroush'
+  ((pageContext.data as HeadMeta | undefined)?.description ?? '') + ' - Masoud Soroush'

--- a/apps/web/src/pages/article/@id/+title.ts
+++ b/apps/web/src/pages/article/@id/+title.ts
@@ -1,5 +1,5 @@
 import type { PageContext } from 'vike/types'
-import type { PageMeta } from './+data'
+import type { HeadMeta } from 'src/renderer/head'
 
 export default (pageContext: PageContext): string =>
-  ((pageContext.data as PageMeta | undefined)?.title ?? 'Article') + ' by Masoud Soroush'
+  ((pageContext.data as HeadMeta | undefined)?.title ?? 'Article') + ' by Masoud Soroush'

--- a/apps/web/src/pages/articles/+data.test.ts
+++ b/apps/web/src/pages/articles/+data.test.ts
@@ -1,17 +1,22 @@
 import { describe, it, expect } from 'vitest'
 import { http, HttpResponse } from 'msw'
+import type { PageContext } from 'vike/types'
 import { server } from 'src/test/mocks/server'
 import { BASE_URL } from 'src/config'
 import queryClient from 'src/utils/api/queryClient'
 import { data } from './+data'
 
 describe('data', () => {
-  it('prefetches the gist list into the query cache', async () => {
+  it('prefetches the gist list and returns social head meta', async () => {
     const gists = [{ id: 'abc123', description: 'a gist' }]
     server.use(http.get(`${BASE_URL}/users/soroushm/gists`, () => HttpResponse.json(gists)))
 
-    await data()
+    const result = await data({
+      config: { title: 'Articles', description: 'All posts.' },
+    } as unknown as PageContext)
 
     expect(queryClient.getQueryData(['gists'])).toEqual(gists)
+    expect(result.meta).toContainEqual({ property: 'og:title', content: 'Articles' })
+    expect(result.meta).toContainEqual({ name: 'description', content: 'All posts.' })
   })
 })

--- a/apps/web/src/pages/articles/+data.test.ts
+++ b/apps/web/src/pages/articles/+data.test.ts
@@ -17,6 +17,6 @@ describe('data', () => {
 
     expect(queryClient.getQueryData(['gists'])).toEqual(gists)
     expect(result.meta).toContainEqual({ property: 'og:title', content: 'Articles' })
-    expect(result.meta).toContainEqual({ name: 'description', content: 'All posts.' })
+    expect(result.meta).toContainEqual({ property: 'og:description', content: 'All posts.' })
   })
 })

--- a/apps/web/src/pages/articles/+data.ts
+++ b/apps/web/src/pages/articles/+data.ts
@@ -1,10 +1,13 @@
+import type { PageContext } from 'vike/types'
 import { prefetchGists } from 'src/hooks/useGists'
+import { pageSocialMeta, type HeadMeta } from 'src/renderer/head'
 
 export { data }
 
 // Prime the gist list into the query cache during SSR/prerender so the static HTML ships the
 // list (SSG) rather than a loader. On the client, useGists (staleTime 0) refetches on mount,
 // so newly published articles still show up.
-async function data() {
+async function data(pageContext: PageContext): Promise<HeadMeta> {
   await prefetchGists()
+  return { meta: pageSocialMeta(pageContext) }
 }

--- a/apps/web/src/pages/contact/+config.ts
+++ b/apps/web/src/pages/contact/+config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'vike/types'
 
 export default {
-  title: 'Contact Masoud',
+  title: 'Contact Masoud Soroush',
   description:
-    'Get in touch with Masoud Soroush — secure inquiry form for projects, collaboration, and engineering work.',
+    'Get in touch with Masoud Soroush — secure inquiry form for projects, collaboration, and software development work.',
 } satisfies Config

--- a/apps/web/src/pages/contact/+data.test.ts
+++ b/apps/web/src/pages/contact/+data.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import type { PageContext } from 'vike/types'
+import { data } from './+data'
+
+describe('data', () => {
+  it('returns social meta with a summary card and no image', () => {
+    const result = data({
+      config: { title: 'Contact', description: 'D' },
+    } as unknown as PageContext)
+    expect(result.meta).toContainEqual({ property: 'og:title', content: 'Contact' })
+    expect(result.meta).toContainEqual({ name: 'twitter:card', content: 'summary' })
+    expect(result.meta?.some((t) => 'property' in t && t.property === 'og:image')).toBe(false)
+  })
+})

--- a/apps/web/src/pages/contact/+data.ts
+++ b/apps/web/src/pages/contact/+data.ts
@@ -1,0 +1,6 @@
+import type { PageContext } from 'vike/types'
+import { pageSocialMeta, type HeadMeta } from 'src/renderer/head'
+
+export function data(pageContext: PageContext): HeadMeta {
+  return { meta: pageSocialMeta(pageContext) }
+}

--- a/apps/web/src/pages/contact/contact.e2e.ts
+++ b/apps/web/src/pages/contact/contact.e2e.ts
@@ -19,7 +19,7 @@ const blurField = async (page: Page, name: RegExp) => {
 test('contact page renders the secure inquiry form', async ({ page }) => {
   await gotoContact(page)
 
-  await expect(page).toHaveTitle('Contact Masoud · SOROUSH.TECH')
+  await expect(page).toHaveTitle('Contact Masoud Soroush · SOROUSH.TECH')
 
   await expect(page.getByRole('heading', { level: 2, name: 'CONTACT INQUIRE' })).toBeVisible()
   await expect(

--- a/apps/web/src/pages/domain/+data.test.ts
+++ b/apps/web/src/pages/domain/+data.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import type { PageContext } from 'vike/types'
+import { data } from './+data'
+
+describe('data', () => {
+  it('returns social meta sourced from config, with the page image', () => {
+    const result = data({
+      config: { title: 'Domains', description: 'D' },
+    } as unknown as PageContext)
+    expect(result.meta).toContainEqual({ property: 'og:title', content: 'Domains' })
+    expect(result.meta).toContainEqual({
+      property: 'og:image',
+      content: 'https://soroush.tech/mock.png',
+    })
+  })
+})

--- a/apps/web/src/pages/domain/+data.ts
+++ b/apps/web/src/pages/domain/+data.ts
@@ -1,0 +1,8 @@
+import type { PageContext } from 'vike/types'
+// +data runs in the normal Vite pipeline, so it can import imagetools assets (unlike +config).
+import detective from 'src/assets/soroush_mascot_detective.png?w=1200&format=png&as=picture'
+import { pageSocialMeta, type HeadMeta } from 'src/renderer/head'
+
+export function data(pageContext: PageContext): HeadMeta {
+  return { meta: pageSocialMeta(pageContext, detective) }
+}

--- a/apps/web/src/pages/experience/+data.test.ts
+++ b/apps/web/src/pages/experience/+data.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import type { PageContext } from 'vike/types'
+import { data } from './+data'
+
+describe('data', () => {
+  it('returns social meta with a summary card and no image', () => {
+    const result = data({
+      config: { title: 'Experience', description: 'D' },
+    } as unknown as PageContext)
+    expect(result.meta).toContainEqual({ property: 'og:title', content: 'Experience' })
+    expect(result.meta).toContainEqual({ name: 'twitter:card', content: 'summary' })
+    expect(result.meta?.some((t) => 'property' in t && t.property === 'og:image')).toBe(false)
+  })
+})

--- a/apps/web/src/pages/experience/+data.ts
+++ b/apps/web/src/pages/experience/+data.ts
@@ -1,0 +1,6 @@
+import type { PageContext } from 'vike/types'
+import { pageSocialMeta, type HeadMeta } from 'src/renderer/head'
+
+export function data(pageContext: PageContext): HeadMeta {
+  return { meta: pageSocialMeta(pageContext) }
+}

--- a/apps/web/src/pages/index/+config.ts
+++ b/apps/web/src/pages/index/+config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'vike/types'
 
 export default {
-  title: 'Masoud Soroush — Principal Software Engineer',
+  title: 'Building High‑Performance Software',
   description:
-    'Engineering scalable, low-latency systems where precision meets innovation. Specialized in distributed cloud environments and resilient micro-services.',
+    'Engineering scalable, low-latency systems where precision meets innovation. Specialized in responsive user interface, architectural, AI integration, distributed cloud environments and resilient micro-services.',
 } satisfies Config

--- a/apps/web/src/pages/index/+data.test.ts
+++ b/apps/web/src/pages/index/+data.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import type { PageContext } from 'vike/types'
+import { data } from './+data'
+
+describe('data', () => {
+  it('returns social meta sourced from config, with the page image', () => {
+    const result = data({ config: { title: 'Home', description: 'D' } } as unknown as PageContext)
+    expect(result.meta).toContainEqual({ property: 'og:title', content: 'Home' })
+    // imagetools is mocked to '/mock.png' in unit tests (see vitest.config.ts).
+    expect(result.meta).toContainEqual({
+      property: 'og:image',
+      content: 'https://soroush.tech/mock.png',
+    })
+  })
+})

--- a/apps/web/src/pages/index/+data.ts
+++ b/apps/web/src/pages/index/+data.ts
@@ -1,0 +1,8 @@
+import type { PageContext } from 'vike/types'
+// +data runs in the normal Vite pipeline, so it can import imagetools assets (unlike +config).
+import portrait from 'src/assets/masoud_soroush.png?w=1200&format=png&as=picture'
+import { pageSocialMeta, type HeadMeta } from 'src/renderer/head'
+
+export function data(pageContext: PageContext): HeadMeta {
+  return { meta: pageSocialMeta(pageContext, portrait) }
+}

--- a/apps/web/src/pages/index/index.e2e.ts
+++ b/apps/web/src/pages/index/index.e2e.ts
@@ -3,7 +3,7 @@ import { test, expect } from 'src/test/e2e/fixtures'
 test('homepage has expected title and meta description', async ({ page }) => {
   await page.goto('/')
 
-  await expect(page).toHaveTitle('Masoud Soroush — Principal Software Engineer · SOROUSH.TECH')
+  await expect(page).toHaveTitle('Building High‑Performance Software · SOROUSH.TECH')
   await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', /\S/)
 
   // Wait for the client app to hydrate so +Page executes (captured by e2e coverage).

--- a/apps/web/src/pages/projects/+data.test.ts
+++ b/apps/web/src/pages/projects/+data.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import type { PageContext } from 'vike/types'
+import { data } from './+data'
+
+describe('data', () => {
+  it('returns social meta with a summary card and no image', () => {
+    const result = data({
+      config: { title: 'Projects', description: 'Selected engineering projects.' },
+    } as unknown as PageContext)
+    expect(result.meta).toContainEqual({ property: 'og:title', content: 'Projects' })
+    expect(result.meta).toContainEqual({ name: 'twitter:card', content: 'summary' })
+    expect(result.meta?.some((t) => 'property' in t && t.property === 'og:image')).toBe(false)
+  })
+})

--- a/apps/web/src/pages/projects/+data.ts
+++ b/apps/web/src/pages/projects/+data.ts
@@ -1,0 +1,6 @@
+import type { PageContext } from 'vike/types'
+import { pageSocialMeta, type HeadMeta } from 'src/renderer/head'
+
+export function data(pageContext: PageContext): HeadMeta {
+  return { meta: pageSocialMeta(pageContext) }
+}

--- a/apps/web/src/renderer/+onRenderHtml.test.tsx
+++ b/apps/web/src/renderer/+onRenderHtml.test.tsx
@@ -70,6 +70,6 @@ describe('+onRenderHtml', () => {
     }
     const result = (await onRenderHtml(pageContext as never)) as unknown as { __html: string }
     expect(result.__html).toContain('<title>About · SOROUSH.TECH</title>')
-    expect(result.__html).toContain('<link rel="canonical" href="https://soroush.tech/about" />')
+    expect(result.__html).toContain('<link rel="canonical" href="https://soroush.tech/about/" />')
   })
 })

--- a/apps/web/src/renderer/buildHead.test.ts
+++ b/apps/web/src/renderer/buildHead.test.ts
@@ -118,7 +118,10 @@ describe('buildHead', () => {
       expect(head).toContain("script-src 'self'")
       expect(head).toContain("style-src 'self' 'unsafe-inline'")
       expect(head).toContain("img-src 'self' https://*.githubusercontent.com data:")
-      expect(head).toContain("connect-src 'self' https://api.github.com")
+      expect(head).toContain("connect-src 'self' https://api.github.com https://api.soroush.tech")
+      // Turnstile: script + challenge iframe from challenges.cloudflare.com
+      expect(head).toContain("script-src 'self' https://challenges.cloudflare.com")
+      expect(head).toContain('frame-src https://challenges.cloudflare.com')
     })
   })
 

--- a/apps/web/src/renderer/buildHead.test.ts
+++ b/apps/web/src/renderer/buildHead.test.ts
@@ -32,10 +32,10 @@ describe('buildHead', () => {
 
     it('renders description, canonical, and website OG tags', () => {
       expect(head).toContain('<meta name="description" content="Who I am." />')
-      expect(head).toContain('<link rel="canonical" href="https://soroush.tech/about" />')
+      expect(head).toContain('<link rel="canonical" href="https://soroush.tech/about/" />')
       expect(head).toContain('<meta property="og:type" content="website" />')
       expect(head).toContain('<meta property="og:title" content="About" />')
-      expect(head).toContain('<meta property="og:url" content="https://soroush.tech/about" />')
+      expect(head).toContain('<meta property="og:url" content="https://soroush.tech/about/" />')
       expect(head).toContain('<meta name="twitter:description" content="Who I am." />')
     })
 
@@ -83,7 +83,7 @@ describe('buildHead', () => {
       expect(head).toContain('"@type":"BlogPosting"')
       expect(head).toContain('"headline":"My Article"')
       expect(head).toContain('"author":{"@type":"Person","name":"Masoud Soroush"}')
-      expect(head).toContain('"mainEntityOfPage":"https://soroush.tech/article/abc"')
+      expect(head).toContain('"mainEntityOfPage":"https://soroush.tech/article/abc/"')
     })
 
     it('omits article time and author tags when absent', () => {

--- a/apps/web/src/renderer/buildHead.test.ts
+++ b/apps/web/src/renderer/buildHead.test.ts
@@ -6,104 +6,114 @@ const ctx = (config?: unknown, urlPathname?: string, data?: unknown) =>
   ({ config, urlPathname, data }) as unknown as PageContext
 
 describe('buildHead', () => {
-  describe('default page (no config)', () => {
+  describe('mechanical tags (no data)', () => {
     const head = buildHead(ctx())
 
     it('falls back to the site title', () => {
       expect(head).toContain('<title>SOROUSH.TECH</title>')
     })
 
-    it('defaults robots to index,follow and og:type to website', () => {
+    it('defaults robots to index,follow', () => {
       expect(head).toContain('<meta name="robots" content="index,follow" />')
-      expect(head).toContain('<meta property="og:type" content="website" />')
     })
 
-    it('omits the description tags when there is none', () => {
-      expect(head).not.toContain('name="description"')
-    })
-  })
-
-  describe('static page (config title + description)', () => {
-    const head = buildHead(ctx({ title: 'About', description: 'Who I am.' }, '/about'))
-
-    it('renders a suffixed title', () => {
-      expect(head).toContain('<title>About · SOROUSH.TECH</title>')
+    it('emits canonical, og:url, og:site_name, and referrer', () => {
+      expect(head).toContain('<link rel="canonical" href="https://soroush.tech/" />')
+      expect(head).toContain('<meta property="og:url" content="https://soroush.tech/" />')
+      expect(head).toContain('<meta property="og:site_name" content="SOROUSH.TECH" />')
+      expect(head).toContain('<meta name="referrer" content="strict-origin-when-cross-origin" />')
     })
 
-    it('renders description, canonical, and website OG tags', () => {
-      expect(head).toContain('<meta name="description" content="Who I am." />')
-      expect(head).toContain('<link rel="canonical" href="https://soroush.tech/about/" />')
-      expect(head).toContain('<meta property="og:type" content="website" />')
-      expect(head).toContain('<meta property="og:title" content="About" />')
-      expect(head).toContain('<meta property="og:url" content="https://soroush.tech/about/" />')
-      expect(head).toContain('<meta name="twitter:description" content="Who I am." />')
-    })
-
-    it('does not render article-only tags', () => {
-      expect(head).not.toContain('article:published_time')
+    it('omits page-owned tags when there is no data', () => {
+      expect(head).not.toContain('og:title')
       expect(head).not.toContain('application/ld+json')
     })
   })
 
-  describe('robots override', () => {
-    it('emits a noindex directive when configured', () => {
-      const head = buildHead(ctx({ title: 'Projects', robots: 'noindex,nofollow' }, '/projects'))
-      expect(head).toContain('<meta name="robots" content="noindex,nofollow" />')
+  describe('title + robots from config', () => {
+    it('renders a suffixed document title', () => {
+      expect(buildHead(ctx({ title: 'About' }))).toContain('<title>About · SOROUSH.TECH</title>')
     })
 
     it('resolves a function title', () => {
-      const head = buildHead(ctx({ title: () => 'Dynamic' }, '/x'))
-      expect(head).toContain('<title>Dynamic · SOROUSH.TECH</title>')
+      expect(buildHead(ctx({ title: () => 'Dynamic' }))).toContain(
+        '<title>Dynamic · SOROUSH.TECH</title>'
+      )
+    })
+
+    it('emits a noindex directive when configured', () => {
+      expect(buildHead(ctx({ robots: 'noindex,nofollow' }))).toContain(
+        '<meta name="robots" content="noindex,nofollow" />'
+      )
     })
   })
 
-  describe('article page (config + data)', () => {
+  describe('canonical/og:url trailing slash', () => {
+    it('keeps a single slash for the home page', () => {
+      expect(buildHead(ctx(undefined, '/'))).toContain('href="https://soroush.tech/"')
+    })
+
+    it('appends a trailing slash to other paths', () => {
+      const head = buildHead(ctx(undefined, '/about'))
+      expect(head).toContain('<link rel="canonical" href="https://soroush.tech/about/" />')
+      expect(head).toContain('<meta property="og:url" content="https://soroush.tech/about/" />')
+    })
+  })
+
+  describe('page-owned meta from data', () => {
     const head = buildHead(
-      ctx({ title: 'My Article', description: 'A summary.' }, '/article/abc', {
-        title: 'My Article',
-        description: 'A summary.',
-        publishedTime: '2021-03-15T10:00:00Z',
-        modifiedTime: '2021-04-01T10:00:00Z',
-        author: 'Masoud Soroush',
+      ctx(undefined, '/about', {
+        meta: [
+          { property: 'og:title', content: 'My OG Title' },
+          { name: 'twitter:card', content: 'summary_large_image' },
+        ],
       })
     )
 
-    it('uses og:type article and renders the article timestamps and author', () => {
-      expect(head).toContain('<meta property="og:type" content="article" />')
-      expect(head).toContain(
-        '<meta property="article:published_time" content="2021-03-15T10:00:00Z" />'
-      )
-      expect(head).toContain(
-        '<meta property="article:modified_time" content="2021-04-01T10:00:00Z" />'
-      )
-      expect(head).toContain('<meta property="article:author" content="Masoud Soroush" />')
-    })
-
-    it('renders BlogPosting JSON-LD with the canonical url', () => {
-      expect(head).toContain('"@type":"BlogPosting"')
-      expect(head).toContain('"headline":"My Article"')
-      expect(head).toContain('"author":{"@type":"Person","name":"Masoud Soroush"}')
-      expect(head).toContain('"mainEntityOfPage":"https://soroush.tech/article/abc/"')
-    })
-
-    it('omits article time and author tags when absent', () => {
-      const minimal = buildHead(
-        ctx({ title: 'T', description: 'D' }, '/article/x', { title: 'T', description: 'D' })
-      )
-      expect(minimal).not.toContain('article:published_time')
-      expect(minimal).not.toContain('"author"')
+    it('renders both name- and property-keyed meta tags', () => {
+      expect(head).toContain('<meta property="og:title" content="My OG Title" />')
+      expect(head).toContain('<meta name="twitter:card" content="summary_large_image" />')
     })
   })
 
-  describe('security tags', () => {
-    afterEach(() => {
-      vi.unstubAllEnvs()
+  describe('jsonLd from data', () => {
+    it('renders a script tag and neutralizes a </script> sequence', () => {
+      const head = buildHead(
+        ctx(undefined, '/article/x/', {
+          jsonLd: { '@type': 'BlogPosting', headline: 'a </script> b' },
+        })
+      )
+      expect(head).toContain('"@type":"BlogPosting"')
+      expect(head).toContain('\\u003c/script> b')
+    })
+  })
+
+  describe('non-HeadMeta data is ignored', () => {
+    it('skips data without meta/jsonLd', () => {
+      const head = buildHead(ctx(undefined, '/x', { foo: 'bar' }))
+      expect(head).not.toContain('og:title')
+      expect(head).not.toContain('application/ld+json')
+    })
+  })
+
+  describe('escaping', () => {
+    it('escapes the document title', () => {
+      expect(buildHead(ctx({ title: 'A & B <x>' }))).toContain(
+        '<title>A &amp; B &lt;x&gt; · SOROUSH.TECH</title>'
+      )
     })
 
-    it('always emits the referrer policy', () => {
-      expect(buildHead(ctx())).toContain(
-        '<meta name="referrer" content="strict-origin-when-cross-origin" />'
+    it('escapes meta tag content', () => {
+      const head = buildHead(
+        ctx(undefined, '/x', { meta: [{ name: 'description', content: 'has "quotes"' }] })
       )
+      expect(head).toContain('content="has &quot;quotes&quot;"')
+    })
+  })
+
+  describe('CSP', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs()
     })
 
     it('omits the CSP in dev (inline HMR scripts would be blocked)', () => {
@@ -115,31 +125,11 @@ describe('buildHead', () => {
       const head = buildHead(ctx())
       expect(head).toContain('<meta http-equiv="Content-Security-Policy" content="')
       expect(head).toContain("default-src 'self'")
-      expect(head).toContain("script-src 'self'")
       expect(head).toContain("style-src 'self' 'unsafe-inline'")
       expect(head).toContain("img-src 'self' https://*.githubusercontent.com data:")
       expect(head).toContain("connect-src 'self' https://api.github.com https://api.soroush.tech")
-      // Turnstile: script + challenge iframe from challenges.cloudflare.com
       expect(head).toContain("script-src 'self' https://challenges.cloudflare.com")
       expect(head).toContain('frame-src https://challenges.cloudflare.com')
-    })
-  })
-
-  describe('escaping', () => {
-    it('escapes HTML in interpolated values', () => {
-      const head = buildHead(ctx({ title: 'A & B <x>', description: 'has "quotes"' }, '/x'))
-      expect(head).toContain('<title>A &amp; B &lt;x&gt; · SOROUSH.TECH</title>')
-      expect(head).toContain('content="has &quot;quotes&quot;"')
-    })
-
-    it('neutralizes a </script> sequence inside the JSON-LD', () => {
-      const head = buildHead(
-        ctx({ title: 'T', description: 'D' }, '/article/x', {
-          title: 'T',
-          description: 'break </script> out',
-        })
-      )
-      expect(head).toContain('\\u003c/script> out')
     })
   })
 })

--- a/apps/web/src/renderer/buildHead.test.ts
+++ b/apps/web/src/renderer/buildHead.test.ts
@@ -48,6 +48,24 @@ describe('buildHead', () => {
     })
   })
 
+  describe('meta description from config', () => {
+    it('renders the page description', () => {
+      expect(buildHead(ctx({ description: 'Who I am.' }))).toContain(
+        '<meta name="description" content="Who I am." />'
+      )
+    })
+
+    it('resolves a function description (e.g. the article +description hook)', () => {
+      expect(buildHead(ctx({ description: () => 'A summary. - Masoud Soroush' }))).toContain(
+        '<meta name="description" content="A summary. - Masoud Soroush" />'
+      )
+    })
+
+    it('omits the description when the config has none', () => {
+      expect(buildHead(ctx())).not.toContain('name="description"')
+    })
+  })
+
   describe('canonical/og:url trailing slash', () => {
     it('keeps a single slash for the home page', () => {
       expect(buildHead(ctx(undefined, '/'))).toContain('href="https://soroush.tech/"')

--- a/apps/web/src/renderer/buildHead.ts
+++ b/apps/web/src/renderer/buildHead.ts
@@ -1,7 +1,7 @@
 import type { PageContext } from 'vike/types'
 import { SITE_URL } from 'src/config'
 import type { HeadMeta, MetaTag } from './head'
-import { SITE_NAME, documentTitle } from './seo'
+import { SITE_NAME, documentTitle, pageDescription } from './seo'
 
 /** Escapes a value for safe interpolation into HTML text and attribute contexts. */
 const escape = (value: string): string =>
@@ -52,6 +52,9 @@ export const buildHead = (pageContext: PageContext): string => {
   const path = pageContext.urlPathname || '/'
   const url = escape(`${SITE_URL}${path.endsWith('/') ? path : `${path}/`}`)
   const head = isHeadMeta(pageContext.data) ? pageContext.data : undefined
+  // Canonical description from the page config, resolved the same way as the title
+  // (article pages supply it via their +description hook). socialMeta owns og/twitter only.
+  const description = pageDescription(pageContext)
 
   const tags = [
     `<title>${escape(documentTitle(pageContext))}</title>`,
@@ -64,6 +67,7 @@ export const buildHead = (pageContext: PageContext): string => {
     `<meta property="og:url" content="${url}" />`,
     `<meta property="og:site_name" content="${SITE_NAME}" />`,
     `<meta name="robots" content="${escape(robots)}" />`,
+    ...(description ? [`<meta name="description" content="${escape(description)}" />`] : []),
     ...(head?.meta ?? []).map(metaTag),
   ]
 

--- a/apps/web/src/renderer/buildHead.ts
+++ b/apps/web/src/renderer/buildHead.ts
@@ -52,7 +52,9 @@ export const buildHead = (pageContext: PageContext): string => {
   const description = pageDescription(pageContext)
   const robots =
     typeof pageContext.config?.robots === 'string' ? pageContext.config.robots : 'index,follow'
-  const url = `${SITE_URL}${pageContext.urlPathname ?? ''}`
+  // Trailing slash matches GitHub Pages, which 301-redirects `/about` -> `/about/`.
+  const path = pageContext.urlPathname || '/'
+  const url = `${SITE_URL}${path.endsWith('/') ? path : `${path}/`}`
   const article = isArticleMeta(pageContext.data) ? pageContext.data : undefined
 
   const ogTitle = escape(title ?? SITE_NAME)

--- a/apps/web/src/renderer/buildHead.ts
+++ b/apps/web/src/renderer/buildHead.ts
@@ -17,12 +17,15 @@ const isArticleMeta = (data: unknown): data is PageMeta =>
 
 // 'unsafe-inline' styles are required by Emotion's critical-CSS extraction;
 // *.githubusercontent.com covers avatars and gist-proxied images.
+// challenges.cloudflare.com loads the Turnstile script and renders its challenge
+// in an iframe (frame-src — otherwise default-src 'self' would block it).
 const CSP = [
   "default-src 'self'",
-  "script-src 'self'",
+  "script-src 'self' https://challenges.cloudflare.com",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' https://*.githubusercontent.com data:",
-  "connect-src 'self' https://api.github.com",
+  "connect-src 'self' https://api.github.com https://api.soroush.tech",
+  'frame-src https://challenges.cloudflare.com',
   "object-src 'none'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/apps/web/src/renderer/buildHead.ts
+++ b/apps/web/src/renderer/buildHead.ts
@@ -1,7 +1,7 @@
 import type { PageContext } from 'vike/types'
-import type { PageMeta } from 'src/pages/article/@id/+data'
 import { SITE_URL } from 'src/config'
-import { SITE_NAME, pageTitle, pageDescription, documentTitle } from './seo'
+import type { HeadMeta, MetaTag } from './head'
+import { SITE_NAME, documentTitle } from './seo'
 
 /** Escapes a value for safe interpolation into HTML text and attribute contexts. */
 const escape = (value: string): string =>
@@ -12,8 +12,8 @@ const escape = (value: string): string =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;')
 
-const isArticleMeta = (data: unknown): data is PageMeta =>
-  typeof data === 'object' && data !== null && 'title' in data
+const isHeadMeta = (data: unknown): data is HeadMeta =>
+  typeof data === 'object' && data !== null && ('meta' in data || 'jsonLd' in data)
 
 // 'unsafe-inline' styles are required by Emotion's critical-CSS extraction;
 // *.githubusercontent.com covers avatars and gist-proxied images.
@@ -31,33 +31,27 @@ const CSP = [
   "form-action 'self'",
 ].join('; ')
 
-const jsonLd = (meta: PageMeta, url: string): string => {
-  const schema = {
-    '@context': 'https://schema.org',
-    '@type': 'BlogPosting',
-    headline: meta.title,
-    description: meta.description,
-    datePublished: meta.publishedTime,
-    dateModified: meta.modifiedTime,
-    author: meta.author ? { '@type': 'Person', name: meta.author } : undefined,
-    mainEntityOfPage: url,
-  }
-  // < guards against a "</script>" sequence breaking out of the tag.
-  return JSON.stringify(schema).replace(/</g, '\\u003c')
-}
+const metaTag = (tag: MetaTag): string =>
+  'name' in tag
+    ? `<meta name="${escape(tag.name)}" content="${escape(tag.content)}" />`
+    : `<meta property="${escape(tag.property)}" content="${escape(tag.content)}" />`
 
-/** Builds the per-page `<head>` tags from the page's config + data (article SEO extras). */
+const jsonLdScript = (data: object): string =>
+  // < guards against a "</script>" sequence breaking out of the tag.
+  `<script type="application/ld+json">${JSON.stringify(data).replace(/</g, '\\u003c')}</script>`
+
+/**
+ * Builds the per-page `<head>`: the mechanical/required tags (title, canonical, og:url, CSP,
+ * referrer, robots, og:site_name) plus the page-owned tags from `+data.ts` (`HeadMeta.meta`
+ * rendered generically, and `HeadMeta.jsonLd` as a script). Pages declare their SEO via `+data`.
+ */
 export const buildHead = (pageContext: PageContext): string => {
-  const title = pageTitle(pageContext)
-  const description = pageDescription(pageContext)
   const robots =
     typeof pageContext.config?.robots === 'string' ? pageContext.config.robots : 'index,follow'
   // Trailing slash matches GitHub Pages, which 301-redirects `/about` -> `/about/`.
   const path = pageContext.urlPathname || '/'
-  const url = `${SITE_URL}${path.endsWith('/') ? path : `${path}/`}`
-  const article = isArticleMeta(pageContext.data) ? pageContext.data : undefined
-
-  const ogTitle = escape(title ?? SITE_NAME)
+  const url = escape(`${SITE_URL}${path.endsWith('/') ? path : `${path}/`}`)
+  const head = isHeadMeta(pageContext.data) ? pageContext.data : undefined
 
   const tags = [
     `<title>${escape(documentTitle(pageContext))}</title>`,
@@ -66,38 +60,14 @@ export const buildHead = (pageContext: PageContext): string => {
       ? []
       : [`<meta http-equiv="Content-Security-Policy" content="${CSP}" />`]),
     `<meta name="referrer" content="strict-origin-when-cross-origin" />`,
-    `<link rel="canonical" href="${escape(url)}" />`,
-    `<meta name="robots" content="${escape(robots)}" />`,
-    `<meta property="og:type" content="${article ? 'article' : 'website'}" />`,
-    `<meta property="og:title" content="${ogTitle}" />`,
-    `<meta property="og:url" content="${escape(url)}" />`,
+    `<link rel="canonical" href="${url}" />`,
+    `<meta property="og:url" content="${url}" />`,
     `<meta property="og:site_name" content="${SITE_NAME}" />`,
-    `<meta name="twitter:card" content="summary" />`,
-    `<meta name="twitter:title" content="${ogTitle}" />`,
+    `<meta name="robots" content="${escape(robots)}" />`,
+    ...(head?.meta ?? []).map(metaTag),
   ]
 
-  if (description) {
-    const desc = escape(description)
-    tags.push(
-      `<meta name="description" content="${desc}" />`,
-      `<meta property="og:description" content="${desc}" />`,
-      `<meta name="twitter:description" content="${desc}" />`
-    )
-  }
-
-  if (article) {
-    if (article.publishedTime)
-      tags.push(
-        `<meta property="article:published_time" content="${escape(article.publishedTime)}" />`
-      )
-    if (article.modifiedTime)
-      tags.push(
-        `<meta property="article:modified_time" content="${escape(article.modifiedTime)}" />`
-      )
-    if (article.author)
-      tags.push(`<meta property="article:author" content="${escape(article.author)}" />`)
-    tags.push(`<script type="application/ld+json">${jsonLd(article, url)}</script>`)
-  }
+  if (head?.jsonLd) tags.push(jsonLdScript(head.jsonLd))
 
   return tags.join('\n    ')
 }

--- a/apps/web/src/renderer/head.test.ts
+++ b/apps/web/src/renderer/head.test.ts
@@ -17,11 +17,12 @@ describe('socialMeta', () => {
     expect(has(tags, 'og:image')).toBe(false)
   })
 
-  it('adds description tags when provided', () => {
+  it('adds og/twitter description tags when provided, but not name=description', () => {
     const tags = socialMeta({ title: 'T', description: 'D' })
-    expect(tags).toContainEqual({ name: 'description', content: 'D' })
     expect(tags).toContainEqual({ property: 'og:description', content: 'D' })
     expect(tags).toContainEqual({ name: 'twitter:description', content: 'D' })
+    // The canonical name=description is owned by buildHead, not socialMeta.
+    expect(has(tags, 'description')).toBe(false)
   })
 
   it('omits description tags when absent', () => {
@@ -58,7 +59,7 @@ describe('pageSocialMeta', () => {
   it('sources title and description from the page config', () => {
     const tags = pageSocialMeta(ctx({ title: 'About', description: 'Who I am.' }))
     expect(tags).toContainEqual({ property: 'og:title', content: 'About' })
-    expect(tags).toContainEqual({ name: 'description', content: 'Who I am.' })
+    expect(tags).toContainEqual({ property: 'og:description', content: 'Who I am.' })
   })
 
   it('falls back to the site name when the config has no title', () => {

--- a/apps/web/src/renderer/head.test.ts
+++ b/apps/web/src/renderer/head.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import type { PageContext } from 'vike/types'
+import { socialMeta, pageSocialMeta } from './head'
+
+const has = (tags: ReturnType<typeof socialMeta>, key: string) =>
+  tags.some((t) => ('name' in t ? t.name : t.property) === key)
+
+const ctx = (config?: unknown) => ({ config }) as unknown as PageContext
+
+describe('socialMeta', () => {
+  it('builds the base website tags with a summary card when there is no image', () => {
+    const tags = socialMeta({ title: 'T' })
+    expect(tags).toContainEqual({ property: 'og:type', content: 'website' })
+    expect(tags).toContainEqual({ property: 'og:title', content: 'T' })
+    expect(tags).toContainEqual({ name: 'twitter:card', content: 'summary' })
+    expect(tags).toContainEqual({ name: 'twitter:title', content: 'T' })
+    expect(has(tags, 'og:image')).toBe(false)
+  })
+
+  it('adds description tags when provided', () => {
+    const tags = socialMeta({ title: 'T', description: 'D' })
+    expect(tags).toContainEqual({ name: 'description', content: 'D' })
+    expect(tags).toContainEqual({ property: 'og:description', content: 'D' })
+    expect(tags).toContainEqual({ name: 'twitter:description', content: 'D' })
+  })
+
+  it('omits description tags when absent', () => {
+    expect(has(socialMeta({ title: 'T' }), 'description')).toBe(false)
+  })
+
+  it('adds an absolute og:image with real dimensions and a large card', () => {
+    const tags = socialMeta({
+      title: 'T',
+      image: { img: { src: '/assets/x.png', w: 1200, h: 630 } },
+    })
+    expect(tags).toContainEqual({
+      property: 'og:image',
+      content: 'https://soroush.tech/assets/x.png',
+    })
+    expect(tags).toContainEqual({ property: 'og:image:width', content: '1200' })
+    expect(tags).toContainEqual({ property: 'og:image:height', content: '630' })
+    expect(tags).toContainEqual({
+      name: 'twitter:image',
+      content: 'https://soroush.tech/assets/x.png',
+    })
+    expect(tags).toContainEqual({ name: 'twitter:card', content: 'summary_large_image' })
+  })
+
+  it('honours the type override', () => {
+    expect(socialMeta({ title: 'T', type: 'article' })).toContainEqual({
+      property: 'og:type',
+      content: 'article',
+    })
+  })
+})
+
+describe('pageSocialMeta', () => {
+  it('sources title and description from the page config', () => {
+    const tags = pageSocialMeta(ctx({ title: 'About', description: 'Who I am.' }))
+    expect(tags).toContainEqual({ property: 'og:title', content: 'About' })
+    expect(tags).toContainEqual({ name: 'description', content: 'Who I am.' })
+  })
+
+  it('falls back to the site name when the config has no title', () => {
+    expect(pageSocialMeta(ctx({}))).toContainEqual({
+      property: 'og:title',
+      content: 'SOROUSH.TECH',
+    })
+  })
+})

--- a/apps/web/src/renderer/head.ts
+++ b/apps/web/src/renderer/head.ts
@@ -30,7 +30,10 @@ interface SocialMetaInput {
   type?: 'website' | 'article'
 }
 
-/** Standard social/SEO meta tags (description, Open Graph, Twitter) for a page. */
+/**
+ * Open Graph / Twitter social meta tags for a page. The canonical `<meta name="description">`
+ * is emitted by buildHead from the page's config (symmetric with the document title).
+ */
 export const socialMeta = ({
   title,
   description,
@@ -45,7 +48,6 @@ export const socialMeta = ({
   ]
   if (description)
     tags.push(
-      { name: 'description', content: description },
       { property: 'og:description', content: description },
       { name: 'twitter:description', content: description }
     )

--- a/apps/web/src/renderer/head.ts
+++ b/apps/web/src/renderer/head.ts
@@ -1,0 +1,70 @@
+import type { PageContext } from 'vike/types'
+import { SITE_URL } from 'src/config'
+import { SITE_NAME, pageTitle, pageDescription } from './seo'
+
+/** A single `<meta>` tag, keyed by either `name` or `property`. */
+export type MetaTag = { name: string; content: string } | { property: string; content: string }
+
+/** An imagetools `?as=picture` import — the bits needed for og:image + its dimensions. */
+export interface Picture {
+  img: { src: string; w: number; h: number }
+}
+
+/**
+ * Per-page head metadata returned by a page's `+data.ts`. `buildHead` renders `meta` generically
+ * and `jsonLd` as a script tag; `title`/`description` are also read by the article `+title`/
+ * `+description` hooks. The mechanical tags (title, canonical, CSP, robots) stay in `buildHead`.
+ */
+export interface HeadMeta {
+  title?: string
+  description?: string
+  meta?: MetaTag[]
+  jsonLd?: object
+}
+
+interface SocialMetaInput {
+  title: string
+  description?: string
+  /** imagetools `?as=picture` import — yields og:image (absolute) + og:image:width/height. */
+  image?: Picture
+  type?: 'website' | 'article'
+}
+
+/** Standard social/SEO meta tags (description, Open Graph, Twitter) for a page. */
+export const socialMeta = ({
+  title,
+  description,
+  image,
+  type = 'website',
+}: SocialMetaInput): MetaTag[] => {
+  const tags: MetaTag[] = [
+    { property: 'og:type', content: type },
+    { property: 'og:title', content: title },
+    { name: 'twitter:card', content: image ? 'summary_large_image' : 'summary' },
+    { name: 'twitter:title', content: title },
+  ]
+  if (description)
+    tags.push(
+      { name: 'description', content: description },
+      { property: 'og:description', content: description },
+      { name: 'twitter:description', content: description }
+    )
+  if (image) {
+    const url = `${SITE_URL}${image.img.src}`
+    tags.push(
+      { property: 'og:image', content: url },
+      { property: 'og:image:width', content: String(image.img.w) },
+      { property: 'og:image:height', content: String(image.img.h) },
+      { name: 'twitter:image', content: url }
+    )
+  }
+  return tags
+}
+
+/** `socialMeta` for a standard page, sourcing title/description from its config. */
+export const pageSocialMeta = (pageContext: PageContext, image?: Picture): MetaTag[] =>
+  socialMeta({
+    title: pageTitle(pageContext) ?? SITE_NAME,
+    description: pageDescription(pageContext),
+    image,
+  })

--- a/apps/web/src/section/CallToAction/CallToAction.test.tsx
+++ b/apps/web/src/section/CallToAction/CallToAction.test.tsx
@@ -14,12 +14,12 @@ describe('CallToAction', () => {
   describe('content', () => {
     it('renders the heading', () => {
       renderWithTheme(<CallToAction />)
-      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument()
     })
 
     it('renders "Something" in the heading', () => {
       renderWithTheme(<CallToAction />)
-      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Something')
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Something')
     })
 
     it('renders the "Great." accent', () => {

--- a/apps/web/src/section/CallToAction/CallToAction.test.tsx
+++ b/apps/web/src/section/CallToAction/CallToAction.test.tsx
@@ -45,7 +45,7 @@ describe('CallToAction', () => {
   describe('CTAs', () => {
     it('renders the Connect Now link to /contact', () => {
       renderWithTheme(<CallToAction />)
-      const cta = screen.getByRole('link', { name: /Connect Now/i })
+      const cta = screen.getByRole('link', { name: /Contact Now/i })
       expect(cta).toBeInTheDocument()
       expect(cta).toHaveAttribute('href', '/contact')
     })

--- a/apps/web/src/section/CallToAction/CallToAction.tsx
+++ b/apps/web/src/section/CallToAction/CallToAction.tsx
@@ -33,7 +33,13 @@ export function CallToAction() {
 
       <View maxWidth="896px" mx="auto" textAlign="center" position="relative" zIndex={1}>
         <Flex alignItems="center" gap={5}>
-          <Typography variant="h1" color="initial" letterSpacing="tighter" lineHeight="tight">
+          <Typography
+            variant="h1"
+            as="h2"
+            color="initial"
+            letterSpacing="tighter"
+            lineHeight="tight"
+          >
             Let&apos;s Build <br /> Something{' '}
             <Typography as="span" color="primary" variant="inherit">
               Great.

--- a/apps/web/src/section/CallToAction/CallToAction.tsx
+++ b/apps/web/src/section/CallToAction/CallToAction.tsx
@@ -57,7 +57,7 @@ export function CallToAction() {
               size="lg"
               letterSpacing="widest"
             >
-              Connect Now
+              Contact Now
             </Button>
           </Flex>
         </Flex>

--- a/apps/web/src/section/ContactInquire/ContactInquire.data.ts
+++ b/apps/web/src/section/ContactInquire/ContactInquire.data.ts
@@ -52,7 +52,7 @@ export const fields = [
     name: 'phone',
     code: '04',
     label: 'PHONE',
-    placeholder: '+49xxxxxx',
+    placeholder: '030-XXXXXX',
     type: 'tel',
     required: false,
     autoComplete: 'tel',
@@ -98,7 +98,6 @@ export const fields = [
 export const success = {
   heading: 'TRANSMISSION RECEIVED',
   subtext: 'Message secured. I’ll respond to your inquiry shortly.',
-  logId: 'SEC_COMM',
   logLines: [
     'HANDSHAKE_SUCCESSFUL',
     'PACKETS_ROUTED_THROUGH_SECURE_NODE',

--- a/apps/web/src/section/ContactInquire/ContactInquire.test.tsx
+++ b/apps/web/src/section/ContactInquire/ContactInquire.test.tsx
@@ -238,6 +238,12 @@ describe('ContactInquire', () => {
       expect(status.textContent).toMatch(/ID: res_\d{9}/)
       expect(posted).toBe(false)
     })
+
+    it('renders no honeypot field when VITE_CONTACT_HONEYPOT is unset', () => {
+      vi.stubEnv('VITE_CONTACT_HONEYPOT', undefined)
+      renderWithApp(<ContactInquire />)
+      expect(document.querySelector('input[data-lpignore="true"]')).toBeNull()
+    })
   })
 
   describe('back navigation', () => {

--- a/apps/web/src/section/ContactInquire/ContactInquire.test.tsx
+++ b/apps/web/src/section/ContactInquire/ContactInquire.test.tsx
@@ -107,15 +107,20 @@ describe('ContactInquire', () => {
   })
 
   describe('submission', () => {
-    it('shows a success panel after a 2xx response', async () => {
-      server.use(http.post(/\/contact$/, () => HttpResponse.json({ ok: true })))
+    it('shows a success panel with the returned reference after a 2xx response', async () => {
+      server.use(
+        http.post(/\/contact$/, () => HttpResponse.json({ ok: true, id: 'REQ-2606-F47AC10B' }))
+      )
       renderWithApp(<ContactInquire />)
 
       fillRequired()
       await waitFor(() => expect(submitButton()).toBeEnabled())
       fireEvent.click(submitButton())
 
-      expect(await screen.findByRole('status')).toHaveTextContent('TRANSMISSION RECEIVED')
+      const status = await screen.findByRole('status')
+      expect(status).toHaveTextContent('TRANSMISSION RECEIVED')
+      // The Worker returns the formatted reference; the panel shows it verbatim.
+      expect(status).toHaveTextContent('REQ-2606-F47AC10B')
       expect(screen.queryByRole('button', { name: /Send/i })).not.toBeInTheDocument()
     })
 
@@ -137,7 +142,9 @@ describe('ContactInquire', () => {
     })
 
     it('resets to a cleared form when New inquiry is clicked on the success panel', async () => {
-      server.use(http.post(/\/contact$/, () => HttpResponse.json({ ok: true })))
+      server.use(
+        http.post(/\/contact$/, () => HttpResponse.json({ ok: true, id: 'abcdef01-2345' }))
+      )
       renderWithApp(<ContactInquire />)
 
       fillRequired()
@@ -159,7 +166,7 @@ describe('ContactInquire', () => {
       server.use(
         http.post(/\/contact$/, () => {
           posted = true
-          return HttpResponse.json({ ok: true })
+          return HttpResponse.json({ ok: true, id: 'abcdef01-2345' })
         })
       )
       renderWithApp(<ContactInquire />)
@@ -225,8 +232,10 @@ describe('ContactInquire', () => {
       fireEvent.change(trap as HTMLInputElement, { target: { value: 'i-am-a-bot' } })
       fireEvent.click(submitButton())
 
-      // Bot sees the decoy success panel, but no request was ever sent.
-      expect(await screen.findByRole('status')).toHaveTextContent('TRANSMISSION RECEIVED')
+      // Bot sees the decoy success panel with a client-side res_ reference, but no request was sent.
+      const status = await screen.findByRole('status')
+      expect(status).toHaveTextContent('TRANSMISSION RECEIVED')
+      expect(status.textContent).toMatch(/ID: res_\d{9}/)
       expect(posted).toBe(false)
     })
   })
@@ -246,6 +255,29 @@ describe('ContactInquire', () => {
       )
 
       fireEvent.click(screen.getByRole('button', { name: /Back/i }))
+      expect(back).toHaveBeenCalledOnce()
+      back.mockRestore()
+    })
+
+    it('renders a Back button on the success panel after in-app navigation', async () => {
+      const back = vi.spyOn(window.history, 'back').mockImplementation(() => undefined)
+      server.use(
+        http.post(/\/contact$/, () => HttpResponse.json({ ok: true, id: 'REQ-2606-F47AC10B' }))
+      )
+      renderWithApp(
+        <PageContext.Provider value={{ isClientSideNavigation: true } as never}>
+          <ContactInquire />
+        </PageContext.Provider>
+      )
+
+      fillRequired()
+      await waitFor(() => expect(submitButton()).toBeEnabled())
+      fireEvent.click(submitButton())
+
+      await screen.findByRole('status')
+      // Two Back buttons now: the card header and the success panel; click the panel's (last).
+      const backButtons = screen.getAllByRole('button', { name: /Back/i })
+      fireEvent.click(backButtons[backButtons.length - 1])
       expect(back).toHaveBeenCalledOnce()
       back.mockRestore()
     })
@@ -272,7 +304,7 @@ describe('ContactInquire', () => {
       server.use(
         http.post(/\/contact$/, async ({ request }) => {
           posted = (await request.json()) as Record<string, unknown>
-          return HttpResponse.json({ ok: true })
+          return HttpResponse.json({ ok: true, id: 'abcdef01-2345' })
         })
       )
       renderWithApp(<ContactInquire />)

--- a/apps/web/src/section/ContactInquire/ContactInquire.tsx
+++ b/apps/web/src/section/ContactInquire/ContactInquire.tsx
@@ -12,6 +12,7 @@ import { Checkbox } from 'src/theme/Checkbox'
 import { Paper } from 'src/theme/Paper'
 import { contact } from '@soroush.tech/schema'
 import { fields, success, type ContactField } from './ContactInquire.data'
+import { makeDecoyId } from './utils'
 import { useContactInquire } from 'src/hooks/useContactInquire'
 import { useContactSubmit } from 'src/hooks/useContactSubmit'
 import { useTurnstile } from 'src/hooks/useTurnstile'
@@ -37,7 +38,9 @@ export function ContactInquire() {
 
   // A tripped honeypot shows the same success screen as a real send (without any request), so a
   // bot gets no signal it was caught — and a real visitor who autofills the trap isn't left stuck.
+  // The decoy carries its own `res_` reference since it never reaches the server to get a real id.
   const [decoySuccess, setDecoySuccess] = useState(false)
+  const [decoyId, setDecoyId] = useState('')
 
   // When a captcha is configured, hold submission until the widget yields a token.
   const captchaPending = Boolean(turnstileSitekey) && !turnstileToken
@@ -58,6 +61,7 @@ export function ContactInquire() {
     }
     // A filled honeypot means a bot — skip the request but show the success screen anyway.
     if (honeypotRef.current?.value) {
+      setDecoyId(makeDecoyId())
       setDecoySuccess(true)
       return
     }
@@ -93,8 +97,23 @@ export function ContactInquire() {
   const gridFields = fields.filter((field) => !field.fullwidth)
   const fullFields = fields.filter((field) => field.fullwidth)
 
+  // Real sends carry a server-formatted reference; the decoy path (no request) uses its own ref.
+  const requestId = submit.data ? submit.data.id : decoyId
+
   return (
     <View as="section" py={6} px={4}>
+      {cameFromApp && (
+        <View mb={4} maxWidth="1280px" mx="auto">
+          <Button
+            variant="text"
+            size="sm"
+            startIcon={<Icon name="arrow_back" size="1.1rem" />}
+            onClick={() => window.history.back()}
+          >
+            Back
+          </Button>
+        </View>
+      )}
       <Paper
         maxWidth="1280px"
         mx="auto"
@@ -109,19 +128,6 @@ export function ContactInquire() {
         <View aria-hidden position="absolute" top={0} right={0} p={4} opacity={0.2}>
           <Icon name="lock" color="primary" size="3.5rem" />
         </View>
-
-        {cameFromApp && (
-          <View mb={6}>
-            <Button
-              variant="text"
-              size="sm"
-              startIcon={<Icon name="arrow_back" size="1.1rem" />}
-              onClick={() => window.history.back()}
-            >
-              Back
-            </Button>
-          </View>
-        )}
 
         <View mb={8} maxWidth="36rem">
           <Typography variant="h2" color="primary" letterSpacing="tighter" gutterBottom>
@@ -154,19 +160,19 @@ export function ContactInquire() {
 
               <Blockquote bg="terminal" p={5} mt={8} width="100%" maxWidth="28rem" textAlign="left">
                 <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
-                  <Typography
-                    variant="caption"
-                    color="primary"
-                    letterSpacing="widest"
-                    textTransform="uppercase"
-                  >
-                    System Log
-                  </Typography>
                   <Typography variant="caption" color="primary" letterSpacing="widest">
-                    LOG_ID: {success.logId}
+                    ID: {requestId}
                   </Typography>
                 </Flex>
                 <View height="1px" bg="grid" mt={2} />
+                <Typography
+                  variant="caption"
+                  color="primary"
+                  letterSpacing="widest"
+                  textTransform="uppercase"
+                >
+                  System Log
+                </Typography>
                 <View mt={3}>
                   {success.logLines.map((line) => (
                     <Typography key={line} variant="caption" as="p" color="secondary">
@@ -176,7 +182,17 @@ export function ContactInquire() {
                 </View>
               </Blockquote>
 
-              <View mt={8}>
+              <Flex flexDirection="row" mt={8} gap={2}>
+                {cameFromApp && (
+                  <Button
+                    variant="contained"
+                    size="lg"
+                    startIcon={<Icon name="arrow_back" size="1.1rem" color="inherit" />}
+                    onClick={() => window.history.back()}
+                  >
+                    Back
+                  </Button>
+                )}
                 <Button
                   variant="contained"
                   size="lg"
@@ -190,7 +206,7 @@ export function ContactInquire() {
                 >
                   New inquiry
                 </Button>
-              </View>
+              </Flex>
             </Flex>
           </View>
         ) : (

--- a/apps/web/src/section/ContactInquire/ContactInquire.tsx
+++ b/apps/web/src/section/ContactInquire/ContactInquire.tsx
@@ -22,7 +22,7 @@ import { Blockquote } from 'src/common/Blockquote'
 export function ContactInquire() {
   // Hidden honeypot field name — read from env so it stays out of the public repo. When unset
   // (e.g. local/dev), the honeypot isn't rendered; the Worker still enforces its own.
-  const honeypotName = import.meta.env.VITE_CONTACT_HONEYPOT
+  const honeypotName = import.meta.env.VITE_CONTACT_HONEYPOT ?? null
   // Turnstile sitekey — read from env like the honeypot. When unset (local/dev) the widget
   // isn't rendered and submission proceeds tokenless; the Worker skips verification in turn.
   const turnstileSitekey = import.meta.env.VITE_TURNSTILE_SITEKEY ?? ''

--- a/apps/web/src/section/ContactInquire/utils.test.ts
+++ b/apps/web/src/section/ContactInquire/utils.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatRequestId, makeDecoyId } from './utils'
-
-describe('formatRequestId', () => {
-  it('formats the first 8 hex chars of a UUID, uppercased', () => {
-    expect(formatRequestId('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe('REQ-F47AC10B')
-  })
-})
+import { makeDecoyId } from './utils'
 
 describe('makeDecoyId', () => {
   it('produces a 9-digit res_ reference', () => {

--- a/apps/web/src/section/ContactInquire/utils.test.ts
+++ b/apps/web/src/section/ContactInquire/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { formatRequestId, makeDecoyId } from './utils'
+
+describe('formatRequestId', () => {
+  it('formats the first 8 hex chars of a UUID, uppercased', () => {
+    expect(formatRequestId('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe('REQ-F47AC10B')
+  })
+})
+
+describe('makeDecoyId', () => {
+  it('produces a 9-digit res_ reference', () => {
+    expect(makeDecoyId()).toMatch(/^res_\d{9}$/)
+  })
+})

--- a/apps/web/src/section/ContactInquire/utils.ts
+++ b/apps/web/src/section/ContactInquire/utils.ts
@@ -1,13 +1,7 @@
 /**
- * Display reference for the success panel, derived from the stored submission UUID: the first 8
- * hex chars, uppercased, e.g. `REQ-F47AC10B`. Short enough to quote in a follow-up; the owner
- * looks it up with `WHERE id LIKE 'f47ac10b%'`.
- */
-export const formatRequestId = (id: string): string => `REQ-${id.slice(0, 8).toUpperCase()}`
-
-/**
  * Client-side decoy reference for the honeypot path, which shows the success panel without ever
- * reaching the server. Distinct `res_` prefix so it never collides with a real `REQ-` id.
+ * reaching the server. Distinct `res_` prefix so it never collides with a real `REQ-` id (the
+ * real reference is formatted server-side; see the Worker's `formatRequestId`).
  */
 export const makeDecoyId = (): string =>
   `res_${String(Math.floor(Math.random() * 1_000_000_000)).padStart(9, '0')}`

--- a/apps/web/src/section/ContactInquire/utils.ts
+++ b/apps/web/src/section/ContactInquire/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Display reference for the success panel, derived from the stored submission UUID: the first 8
+ * hex chars, uppercased, e.g. `REQ-F47AC10B`. Short enough to quote in a follow-up; the owner
+ * looks it up with `WHERE id LIKE 'f47ac10b%'`.
+ */
+export const formatRequestId = (id: string): string => `REQ-${id.slice(0, 8).toUpperCase()}`
+
+/**
+ * Client-side decoy reference for the honeypot path, which shows the success panel without ever
+ * reaching the server. Distinct `res_` prefix so it never collides with a real `REQ-` id.
+ */
+export const makeDecoyId = (): string =>
+  `res_${String(Math.floor(Math.random() * 1_000_000_000)).padStart(9, '0')}`

--- a/apps/web/src/section/CoreEngine/CoreEngine.test.tsx
+++ b/apps/web/src/section/CoreEngine/CoreEngine.test.tsx
@@ -20,7 +20,7 @@ describe('CoreEngine', () => {
 
     it('renders the heading', () => {
       renderWithTheme(<CoreEngine />)
-      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
         'CORE ENGINE SPECIFICATIONS'
       )
     })

--- a/apps/web/src/section/CoreEngine/CoreEngine.tsx
+++ b/apps/web/src/section/CoreEngine/CoreEngine.tsx
@@ -29,7 +29,13 @@ export function CoreEngine() {
           <Typography variant="overline" color="primary" fontWeight="bold" letterSpacing="widest">
             MODERN TOOLING
           </Typography>
-          <Typography variant="h1" color="initial" fontWeight="black" letterSpacing="tighter">
+          <Typography
+            variant="h1"
+            as="h2"
+            color="initial"
+            fontWeight="black"
+            letterSpacing="tighter"
+          >
             CORE ENGINE SPECIFICATIONS
           </Typography>
         </Flex>

--- a/apps/web/src/section/GroundUp/GroundUp.test.tsx
+++ b/apps/web/src/section/GroundUp/GroundUp.test.tsx
@@ -19,7 +19,7 @@ describe('GroundUp', () => {
 
     it('renders the heading', () => {
       renderWithTheme(<GroundUp />)
-      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
         'COMPLEX CHALLENGES // ROBUST SOLUTIONS'
       )
     })

--- a/apps/web/src/section/GroundUp/GroundUp.tsx
+++ b/apps/web/src/section/GroundUp/GroundUp.tsx
@@ -19,6 +19,7 @@ export function GroundUp() {
 
         <Typography
           variant="h1"
+          as="h2"
           color="initial"
           fontWeight="black"
           letterSpacing="tighter"

--- a/apps/web/src/test/e2e/seo.e2e.ts
+++ b/apps/web/src/test/e2e/seo.e2e.ts
@@ -10,7 +10,7 @@ test('each page declares a self-referential https canonical URL', async ({ reque
   const articles = await request.get('/articles')
   expect(articles.status()).toBe(200)
   expect(await articles.text()).toContain(
-    '<link rel="canonical" href="https://soroush.tech/articles" />'
+    '<link rel="canonical" href="https://soroush.tech/articles/" />'
   )
 })
 
@@ -34,7 +34,7 @@ test('sitemap.xml lists indexable pages and omits noindex ones', async ({ reques
   expect(res.status()).toBe(200)
   const xml = await res.text()
   expect(xml).toContain('<loc>https://soroush.tech/</loc>')
-  expect(xml).toContain('<loc>https://soroush.tech/articles</loc>')
+  expect(xml).toContain('<loc>https://soroush.tech/articles/</loc>')
   // noindex pages must never be listed.
   expect(xml).not.toContain('/projects</loc>')
   expect(xml).not.toContain('/design/system</loc>')

--- a/apps/web/src/test/e2e/seo.e2e.ts
+++ b/apps/web/src/test/e2e/seo.e2e.ts
@@ -5,7 +5,11 @@ test('each page declares a self-referential https canonical URL', async ({ reque
   // both the dev-server runs and the production-build run — no E2E_COVERAGE gate needed.
   const home = await request.get('/')
   expect(home.status()).toBe(200)
-  expect(await home.text()).toContain('<link rel="canonical" href="https://soroush.tech/" />')
+  const homeHtml = await home.text()
+  expect(homeHtml).toContain('<link rel="canonical" href="https://soroush.tech/" />')
+  // Home maps to the portrait, so it carries an absolute og:image (asset URL differs
+  // between the dev-server and prod-build runs, so match the prefix only).
+  expect(homeHtml).toMatch(/<meta property="og:image" content="https:\/\/soroush\.tech\//)
 
   const articles = await request.get('/articles')
   expect(articles.status()).toBe(200)

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -47,6 +47,10 @@ export default defineConfig({
     },
   },
   server: {
+    // Playwright runs the dev server on a dedicated port (E2E_PORT) so it never
+    // reuses a developer's `pnpm dev` on 3000 (which has MSW off). Unset → vike's
+    // default 3000 for normal dev. Vike rejects a `--port` CLI flag, so set it here.
+    ...(process.env.E2E_PORT ? { port: Number(process.env.E2E_PORT), strictPort: true } : {}),
     // Keep the test coverage output out of the dev server: don't watch it (no
     // reload churn when `pnpm test:coverage` writes it) and don't serve it.
     watch: { ignored: ['**/coverage/**'] },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "scripts": {
     "prepare": "husky",
+    "postprepare": "pnpm -r run setup",
+    "setup": "pnpm -r run setup",
     "format": "prettier --write .",
     "dev": "pnpm --parallel -r dev",
     "dev:web": "pnpm --filter @soroush/web dev",

--- a/packages/vite-plugin-sitemap/src/index.test.ts
+++ b/packages/vite-plugin-sitemap/src/index.test.ts
@@ -72,7 +72,7 @@ describe('sitemap', () => {
     // index.html -> '/', about has a lastmod, projects is noindex, app.js is not html.
     expect(xml).toContain('<url><loc>https://soroush.tech/</loc></url>')
     expect(xml).toContain(
-      '<url><loc>https://soroush.tech/about</loc><lastmod>2024-03-04</lastmod></url>'
+      '<url><loc>https://soroush.tech/about/</loc><lastmod>2024-03-04</lastmod></url>'
     )
     expect(xml).not.toContain('/projects')
     expect(xml).not.toContain('app.js')

--- a/packages/vite-plugin-sitemap/src/index.ts
+++ b/packages/vite-plugin-sitemap/src/index.ts
@@ -14,14 +14,13 @@ const meta = (html: string, name: string): string | undefined => {
   return match ? (match[1] ?? match[2]) : undefined
 }
 
-// `about/index.html` -> `/about`, `index.html` -> `/`, `article/x/index.html` -> `/article/x`.
-const toPath = (relative: string): string => {
-  const url = relative
+// `about/index.html` -> `/about/`, `index.html` -> `/`, `article/x/index.html` -> `/article/x/`.
+// Trailing slashes match GitHub Pages, which 301-redirects `/about` -> `/about/`.
+const toPath = (relative: string): string =>
+  `/${relative
     .split(sep)
     .join('/')
-    .replace(/\/?index\.html$/, '')
-  return `/${url}`.replace(/\/$/, '') || '/'
-}
+    .replace(/index\.html$/, '')}`
 
 const generate = (clientDir: string): number => {
   const entries = readdirSync(clientDir, { recursive: true })

--- a/workers/README.md
+++ b/workers/README.md
@@ -1,3 +1,11 @@
 # workers/
 
-Backend deployables (Cloudflare Workers, APIs). Empty for now — populated by follow-up work after the monorepo restructure (Epic #147).
+Backend deployables (Cloudflare Workers, APIs).
+
+| Worker                     | What it is                                                                                  | Details                          |
+| -------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------- |
+| **`api`** (`@soroush/api`) | Hono API at `api.soroush.tech` — contact-form intake (`POST /v1/contact`) + a monthly cron. | [api/worker.md](./api/worker.md) |
+
+Each worker configures itself: its `setup` (also run on `predev`/`predeploy`) generates
+`wrangler.json` from `default.wrangler.json` + env via `pnpm config:gen` — `wrangler.json` is
+generated, never committed. See [api/worker.md](./api/worker.md) for conventions and config.

--- a/workers/api/README.md
+++ b/workers/api/README.md
@@ -1,7 +1,7 @@
 # @soroush/api
 
 The contact-form backend Worker (Hono). Exposes `POST /v1/contact` and a `GET /v1/health`
-check, persists submissions to D1, and emails the owner via Cloudflare Email Sending.
+check, persists submissions to D1, and emails the owner via the Resend HTTP API.
 
 ## Data model & retention
 
@@ -38,10 +38,11 @@ CORS is locked to `https://soroush.tech` and `https://www.soroush.tech`.
 ## Bindings & config
 
 `wrangler.json` is **generated from env** (see the `default.wrangler.json` template and
-`scripts/gen-wrangler.mjs`) so no IDs land in the repo. Bindings: `DB` (D1), `BACKUPS` (R2),
-`EMAIL` (Email Sending). Vars: `VITE_CONTACT_HONEYPOT` (hidden field name, shared key with the web),
-`RETENTION_MONTHS`
-(default `6`). The schema template `*.sql` is bundled as a string via wrangler's default `Text`
+`scripts/gen-wrangler.mjs`) so no IDs land in the repo. Bindings: `DB` (D1), `BACKUPS` (R2).
+Secrets: `RESEND_API_KEY` (Resend send), `TURNSTILE_SECRET` (captcha). Vars:
+`VITE_CONTACT_HONEYPOT` (hidden field name, shared key with the web), `RETENTION_MONTHS`
+(default `6`), `TURNSTILE_HOSTNAME` (comma-separated hostnames a Turnstile token may be solved on;
+set in prod config only, so the local test secret keeps working). The schema template `*.sql` is bundled as a string via wrangler's default `Text`
 module rule.
 
 Month tables are created at runtime, so **no `wrangler d1 migrations apply` is needed** — a fresh
@@ -55,17 +56,22 @@ retired rather than kept forever, e.g. via `wrangler r2 bucket lifecycle ...` or
 
 ## One-time email setup
 
-Email Sending is outbound-only and coexists with Google Workspace handling inbound mail —
-**do not enable Email Routing** on the domain (it would hijack MX).
+Email is sent via [Resend](https://resend.com) (free tier) over HTTPS — sending-only, so it
+coexists with Google Workspace handling inbound mail. **Do not enable Cloudflare Email Routing**
+on the domain (it would hijack the Google MX).
 
-1. `wrangler email sending enable soroush.tech`
-2. Add the DKIM CNAME records Cloudflare provides.
-3. **Merge** the SPF record with Google's, e.g.
-   `v=spf1 include:_spf.google.com include:<cloudflare-send-include> ~all` — do not replace it.
+1. Create a Resend account and **verify `soroush.tech`** (Domains → Add) — add exactly the
+   records Resend lists (DKIM `resend._domainkey` + a `send.` subdomain MX/SPF). These are
+   sending-only on a subdomain, so the apex `MX` for Google stays untouched. Separately, the apex
+   has **no SPF** today — add `v=spf1 include:_spf.google.com ~all` for your Google-sent mail.
+2. Create a Resend API key and set it as the Worker secret:
+   `wrangler secret put RESEND_API_KEY`.
+3. For local dev, put `RESEND_API_KEY` where the other dev secrets live (see `default.env`).
 
-Mail is sent from `contact@soroush.tech` to `masoud@soroush.tech`, `replyTo` the submitter.
+Mail is sent from `contact@soroush.tech` to `masoud@soroush.tech`, `reply_to` the submitter.
 
 ## Testing
 
 `pnpm --filter @soroush/api test:coverage` — the Hono app is exercised in-process via
-`app.request()` with mocked D1/R2/EMAIL bindings; 100% coverage is required.
+`app.request()` with mocked D1/R2 bindings and a stubbed `fetch` (Resend + Turnstile); 100%
+coverage is required.

--- a/workers/api/default.env
+++ b/workers/api/default.env
@@ -2,6 +2,7 @@ WORKER_NAME=soroush-local
 D1_DATABASE_NAME=soroush-db-local
 D1_DATABASE_ID=soroush-dev
 R2_BUCKET=soroush-r2-local
+RESEND_API_KEY=re_local_placeholder
 TURNSTILE_SECRET=1x0000000000000000000000000000000AA
 # Local web origin allowed through CORS in dev (match the Vite dev server's port). Never set in production.
 ALLOW_ORIGIN=http://localhost:3000

--- a/workers/api/default.env
+++ b/workers/api/default.env
@@ -7,5 +7,6 @@ RESEND_API_KEY=re_local_placeholder
 TURNSTILE_SECRET=1x0000000000000000000000000000000AA
 # Local web origin allowed through CORS in dev (match the Vite dev server's port). Never set in production.
 ALLOW_ORIGIN=http://localhost:3000
+TURNSTILE_HOSTNAME=example.com
 # Serve Swagger UI (/v1/docs) + OpenAPI (/v1/openapi.json) locally. Never set in production.
 DOCS_ENABLED=true

--- a/workers/api/default.env
+++ b/workers/api/default.env
@@ -2,6 +2,7 @@ WORKER_NAME=soroush-local
 D1_DATABASE_NAME=soroush-db-local
 D1_DATABASE_ID=soroush-dev
 R2_BUCKET=soroush-r2-local
+VITE_CONTACT_HONEYPOT=info
 RESEND_API_KEY=re_local_placeholder
 TURNSTILE_SECRET=1x0000000000000000000000000000000AA
 # Local web origin allowed through CORS in dev (match the Vite dev server's port). Never set in production.

--- a/workers/api/default.wrangler.json
+++ b/workers/api/default.wrangler.json
@@ -7,7 +7,6 @@
     { "name": "RATE_LIMITER", "namespace_id": "1001", "simple": { "limit": 3, "period": 60 } }
   ],
   "routes": [{ "pattern": "api.soroush.tech", "custom_domain": true }],
-  "send_email": [{ "name": "EMAIL" }],
   "d1_databases": [
     {
       "binding": "DB",

--- a/workers/api/default.wrangler.json
+++ b/workers/api/default.wrangler.json
@@ -16,5 +16,9 @@
   ],
   "r2_buckets": [{ "binding": "BACKUPS", "bucket_name": "${R2_BUCKET}" }],
   "triggers": { "crons": ["0 3 1 * *"] },
-  "vars": { "VITE_CONTACT_HONEYPOT": "${VITE_CONTACT_HONEYPOT}", "RETENTION_MONTHS": "3" }
+  "vars": {
+    "VITE_CONTACT_HONEYPOT": "${VITE_CONTACT_HONEYPOT}",
+    "RETENTION_MONTHS": "3",
+    "TURNSTILE_HOSTNAME": "soroush.tech,www.soroush.tech"
+  }
 }

--- a/workers/api/package.json
+++ b/workers/api/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "config:gen": "node scripts/gen-wrangler.mjs",
+    "setup": "node scripts/setup-env.mjs",
     "predev": "pnpm config:gen",
     "dev": "wrangler dev",
     "predeploy": "pnpm config:gen",

--- a/workers/api/scripts/setup-env.mjs
+++ b/workers/api/scripts/setup-env.mjs
@@ -1,0 +1,21 @@
+import { copyFileSync, existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Bootstrap the local env: copy default.env -> .env on first setup. gen-wrangler.mjs reads .env
+// for the Cloudflare IDs it substitutes into wrangler.json; without it config:gen no-ops.
+const dir = dirname(fileURLToPath(import.meta.url))
+const template = resolve(dir, '../default.env')
+const target = resolve(dir, '../.env')
+
+if (process.env.CI) {
+  // CD supplies the IDs via ambient env (cd-worker-api.yml); a generated .env must not appear in CI.
+  console.log('setup-env: CI detected — skipping workers/api/.env')
+} else if (!existsSync(template)) {
+  console.log('setup-env: no workers/api/default.env template — nothing to copy')
+} else if (existsSync(target)) {
+  console.log('setup-env: workers/api/.env already exists — leaving it untouched')
+} else {
+  copyFileSync(template, target)
+  console.log('setup-env: created workers/api/.env from default.env')
+}

--- a/workers/api/scripts/setup-env.test.mjs
+++ b/workers/api/scripts/setup-env.test.mjs
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { existsSync, copyFileSync } = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  copyFileSync: vi.fn(),
+}))
+
+vi.mock('node:fs', () => ({ existsSync, copyFileSync }))
+
+// The script runs its branch table as a side effect on import, so re-import it per case.
+const run = async () => {
+  vi.resetModules()
+  await import('./setup-env.mjs')
+}
+
+describe('setup-env', () => {
+  let log
+  const originalCI = process.env.CI
+
+  beforeEach(() => {
+    existsSync.mockReset()
+    copyFileSync.mockReset()
+    log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    delete process.env.CI
+  })
+
+  afterEach(() => {
+    log.mockRestore()
+    if (originalCI === undefined) delete process.env.CI
+    else process.env.CI = originalCI
+  })
+
+  it('skips in CI without touching the filesystem', async () => {
+    process.env.CI = '1'
+    await run()
+    expect(copyFileSync).not.toHaveBeenCalled()
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('CI detected'))
+  })
+
+  it('does nothing when the template is missing', async () => {
+    existsSync.mockReturnValue(false)
+    await run()
+    expect(copyFileSync).not.toHaveBeenCalled()
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('nothing to copy'))
+  })
+
+  it('leaves an existing .env untouched', async () => {
+    existsSync.mockReturnValue(true)
+    await run()
+    expect(copyFileSync).not.toHaveBeenCalled()
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('already exists'))
+  })
+
+  it('copies default.env -> .env on first setup', async () => {
+    existsSync.mockImplementation((path) => path.endsWith('default.env'))
+    await run()
+    expect(copyFileSync).toHaveBeenCalledOnce()
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('created'))
+  })
+})

--- a/workers/api/src/app.test.ts
+++ b/workers/api/src/app.test.ts
@@ -3,9 +3,13 @@ import { app } from './app'
 import worker from './index'
 import type { Env } from './env'
 
-/** Minimal env for /health + CORS + docs tests. */
-const makeEnv = (devOrigin?: string, docsEnabled = false) =>
-  ({ ALLOW_ORIGIN: devOrigin, DOCS_ENABLED: docsEnabled ? 'true' : undefined }) as unknown as Env
+/** Minimal env for /health + CORS + docs + guard tests. */
+const makeEnv = (devOrigin?: string, docsEnabled = false, rateLimitOk = true) =>
+  ({
+    ALLOW_ORIGIN: devOrigin,
+    DOCS_ENABLED: docsEnabled ? 'true' : undefined,
+    RATE_LIMITER: { limit: async () => ({ success: rateLimitOk }) },
+  }) as unknown as Env
 
 describe('@soroush/api', () => {
   it('GET /v1/health returns 200 { ok: true }', async () => {
@@ -52,6 +56,91 @@ describe('@soroush/api', () => {
 
   it('exposes a fetch handler as the default export', async () => {
     const res = await worker.fetch(new Request('https://api.soroush.tech/v1/health'), makeEnv())
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('origin guard', () => {
+  it('403s a guarded request with no Origin or Referer', async () => {
+    const res = await app.request('/v1/contact', { method: 'POST' }, makeEnv())
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({ ok: false, error: 'Forbidden' })
+  })
+
+  it('403s a guarded request whose Referer is unparseable', async () => {
+    const res = await app.request(
+      '/v1/contact',
+      { method: 'POST', headers: { Referer: 'not a url' } },
+      makeEnv()
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('lets through a request from an allowed Origin', async () => {
+    const res = await app.request(
+      '/v1/contact',
+      { method: 'POST', headers: { Origin: 'https://soroush.tech' } },
+      makeEnv()
+    )
+    expect(res.status).not.toBe(403)
+  })
+
+  it('lets through a request whose Referer is on an allowed origin', async () => {
+    const res = await app.request(
+      '/v1/contact',
+      { method: 'POST', headers: { Referer: 'https://soroush.tech/contact' } },
+      makeEnv()
+    )
+    expect(res.status).not.toBe(403)
+  })
+
+  it('lets through the configured dev origin (local development only)', async () => {
+    const res = await app.request(
+      '/v1/contact',
+      { method: 'POST', headers: { Origin: 'http://localhost:5173' } },
+      makeEnv('http://localhost:5173')
+    )
+    expect(res.status).not.toBe(403)
+  })
+
+  it('does not guard /health (uptime monitors send no Origin)', async () => {
+    const res = await app.request('/v1/health', {}, makeEnv())
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('rate limit', () => {
+  it('429s when the per-IP limit is exceeded', async () => {
+    const res = await app.request(
+      '/v1/contact',
+      {
+        method: 'POST',
+        headers: { Origin: 'https://soroush.tech', 'cf-connecting-ip': '203.0.113.7' },
+      },
+      makeEnv(undefined, false, false)
+    )
+    expect(res.status).toBe(429)
+    expect(await res.json()).toEqual({ ok: false, error: 'Too many requests' })
+  })
+
+  it('lets a request through when under the limit', async () => {
+    const res = await app.request(
+      '/v1/contact',
+      {
+        method: 'POST',
+        headers: { Origin: 'https://soroush.tech', 'cf-connecting-ip': '203.0.113.7' },
+      },
+      makeEnv(undefined, false, true)
+    )
+    expect(res.status).not.toBe(429)
+  })
+
+  it('does not rate-limit /health (frequent uptime polls)', async () => {
+    const res = await app.request(
+      '/v1/health',
+      { headers: { 'cf-connecting-ip': '203.0.113.7' } },
+      makeEnv(undefined, false, false)
+    )
     expect(res.status).toBe(200)
   })
 })

--- a/workers/api/src/app.ts
+++ b/workers/api/src/app.ts
@@ -17,6 +17,23 @@ const ALLOWED_ORIGINS = ['https://soroush.tech', 'https://www.soroush.tech']
 const resolveOrigin = (origin: string, c: Context<{ Bindings: Env }>) =>
   ALLOWED_ORIGINS.includes(origin) || origin === c.env.ALLOW_ORIGIN ? origin : null
 
+/**
+ * Paths exempt from the origin guard and rate limit: `/health` (uptime monitors send no Origin and
+ * poll frequently) and the docs routes (opened by direct browser navigation, which also sends no
+ * Origin; already gated by `DOCS_ENABLED`).
+ */
+const GUARD_EXEMPT = ['/v1/health', '/v1/docs', '/v1/openapi.json']
+
+/** Origin of a `Referer` header, or `null` when it's absent or unparseable. */
+const refererOrigin = (referer: string | undefined): string | null => {
+  if (!referer) return null
+  try {
+    return new URL(referer).origin
+  } catch {
+    return null
+  }
+}
+
 /** Docs (Swagger UI + OpenAPI) are served only when `DOCS_ENABLED` is set — never in production. */
 const docsEnabled = (c: { env: Env }) => c.env.DOCS_ENABLED === 'true'
 
@@ -28,13 +45,41 @@ export const createApp = () => {
   const app = new Hono<{ Bindings: Env }>().basePath('/v1')
 
   app.use(
-    '*',
+    '/*',
     cors({
       origin: resolveOrigin,
       allowMethods: ['POST', 'OPTIONS'],
       allowHeaders: ['Content-Type', 'Authorization'],
     })
   )
+
+  // Belt-and-suspenders origin gate: reject requests whose Origin (or Referer, as a fallback) is
+  // not our site before they reach a route. Non-browser clients can forge these headers, so this
+  // is noise reduction, not security — Turnstile is the real gate. `cors()` above already
+  // short-circuits the OPTIONS preflight, so only real requests reach here.
+  app.use('/*', async (c, next) => {
+    if (GUARD_EXEMPT.includes(c.req.path)) return next()
+    const allowed = c.env.ALLOW_ORIGIN ? [...ALLOWED_ORIGINS, c.env.ALLOW_ORIGIN] : ALLOWED_ORIGINS
+    const origin = c.req.header('Origin')
+    const allowedByOrigin = origin ? allowed.includes(origin) : false
+    const allowedByReferer = allowed.includes(refererOrigin(c.req.header('Referer')) ?? '')
+    if (!allowedByOrigin && !allowedByReferer) {
+      return c.json({ ok: false, error: 'Forbidden' }, 403)
+    }
+    return next()
+  })
+
+  // Per-IP rate limit across all routes. `cf-connecting-ip` is always set behind Cloudflare; it's
+  // absent only in local dev / direct access, where we skip rather than block.
+  app.use('/*', async (c, next) => {
+    if (GUARD_EXEMPT.includes(c.req.path)) return next()
+    const ip = c.req.header('cf-connecting-ip')
+    if (ip) {
+      const { success } = await c.env.RATE_LIMITER.limit({ key: ip })
+      if (!success) return c.json({ ok: false, error: 'Too many requests' }, 429)
+    }
+    return next()
+  })
 
   app.get('/health', (c) => c.json({ ok: true }))
   app.route('/', contactRoute)

--- a/workers/api/src/env.ts
+++ b/workers/api/src/env.ts
@@ -14,6 +14,12 @@ export interface Env {
   RESEND_API_KEY: string
   /** Cloudflare Turnstile secret (a Worker secret). Empty disables captcha verification. */
   TURNSTILE_SECRET: string
+  /**
+   * Comma-separated hostnames a Turnstile token may be solved on (e.g.
+   * `soroush.tech,www.soroush.tech`). Unset/empty skips the hostname check — set only in
+   * production config, so the local test secret keeps working.
+   */
+  TURNSTILE_HOSTNAME?: string
   /** Per-IP rate limiter for the contact endpoint (1 request / 60s). */
   RATE_LIMITER: RateLimit
   /** When `'true'`, serve Swagger UI + OpenAPI (local/preview only; never set in production). */

--- a/workers/api/src/env.ts
+++ b/workers/api/src/env.ts
@@ -1,15 +1,3 @@
-/** Minimal shape of the Cloudflare Email Sending binding used to notify the owner. */
-export interface EmailSendBinding {
-  send(message: {
-    to: string
-    from: { email: string; name?: string }
-    replyTo?: string
-    subject: string
-    html: string
-    text: string
-  }): Promise<unknown>
-}
-
 /** Cloudflare Workers rate-limit binding: `limit({ key })` → `{ success }`. */
 export interface RateLimit {
   limit(options: { key: string }): Promise<{ success: boolean }>
@@ -22,8 +10,8 @@ export interface Env {
   DB: D1Database
   /** R2 bucket where retention archives expired submissions. */
   BACKUPS: R2Bucket
-  /** Cloudflare Email Sending binding for owner notifications. */
-  EMAIL: EmailSendBinding
+  /** Resend API key (a Worker secret) for sending owner notifications via the Resend HTTP API. */
+  RESEND_API_KEY: string
   /** Cloudflare Turnstile secret (a Worker secret). Empty disables captcha verification. */
   TURNSTILE_SECRET: string
   /** Per-IP rate limiter for the contact endpoint (1 request / 60s). */

--- a/workers/api/src/openapi.ts
+++ b/workers/api/src/openapi.ts
@@ -15,6 +15,27 @@ const okResponse = {
   },
 }
 
+/** Contact 200 body: `{ ok: true, id }`. `id` is omitted for dropped honeypot hits. */
+const contactOkResponse = {
+  description: 'Success',
+  content: {
+    'application/json': {
+      schema: {
+        type: 'object',
+        properties: {
+          ok: { type: 'boolean', const: true },
+          id: {
+            type: 'string',
+            description:
+              'Short reference for the stored submission, e.g. REQ-2606-F47AC10B. Omitted for dropped honeypot hits.',
+          },
+        },
+        required: ['ok'],
+      },
+    },
+  },
+}
+
 /** Error body: `{ ok: false, error: string }`. */
 const errorResponse = (description: string) => ({
   description,
@@ -104,7 +125,7 @@ export const openApiDocument = {
           },
         },
         responses: {
-          '200': okResponse,
+          '200': contactOkResponse,
           '400': validationErrorResponse,
           '403': errorResponse('Captcha verification failed'),
           '413': errorResponse('Payload too large'),

--- a/workers/api/src/routes/contact.test.ts
+++ b/workers/api/src/routes/contact.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { app } from 'src/app'
 import type { Env } from 'src/env'
 import { monthTableName } from 'src/utils/tables'
@@ -17,20 +17,14 @@ const valid = {
   consent: true,
 }
 
-/** Fake env: D1 records prepared SQL + bound insert args, EMAIL records (or fails) sends. */
-const makeEnv = (
-  honeypot = 'fax',
-  emailFails = false,
-  turnstileSecret = '',
-  rateLimitOk = true
-) => {
+/** Fake env: D1 records prepared SQL + bound insert args. Email/Turnstile go over `fetch`. */
+const makeEnv = (honeypot = 'fax', turnstileSecret = '') => {
   const sqls: string[] = []
   const inserts: unknown[][] = []
-  const emails: unknown[] = []
   const env = {
     VITE_CONTACT_HONEYPOT: honeypot,
+    RESEND_API_KEY: 'test-key',
     TURNSTILE_SECRET: turnstileSecret,
-    RATE_LIMITER: { limit: async () => ({ success: rateLimitOk }) },
     DB: {
       prepare: (sql: string) => {
         sqls.push(sql)
@@ -47,22 +41,46 @@ const makeEnv = (
       },
     },
     BACKUPS: {},
-    EMAIL: {
-      send: async (message: unknown) => {
-        if (emailFails) throw new Error('email down')
-        emails.push(message)
-      },
-    },
   } as unknown as Env
-  return { env, sqls, inserts, emails }
+  return { env, sqls, inserts }
 }
+
+/**
+ * Stub the two outbound fetches the route makes: Turnstile siteverify (returns `{ success }`) and
+ * the Resend email POST (returns ok/!ok). Returns the requested URLs for assertions.
+ */
+const stubFetch = ({ turnstileOk = true, emailOk = true, hostname = 'soroush.tech' } = {}) => {
+  const urls: string[] = []
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string | URL) => {
+      const url = String(input)
+      urls.push(url)
+      if (url.includes('api.resend.com')) {
+        return { ok: emailOk, status: emailOk ? 200 : 500 } as Response
+      }
+      return new Response(JSON.stringify({ success: turnstileOk, hostname }))
+    })
+  )
+  return urls
+}
+
+beforeEach(() => {
+  stubFetch()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 const post = (body: unknown, env: Env, headers: Record<string, string> = {}) =>
   app.request(
     '/v1/contact',
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...headers },
+      // An allowed Origin so requests clear the app-level origin guard; the guard itself is
+      // covered in app.test.ts.
+      headers: { 'Content-Type': 'application/json', Origin: 'https://soroush.tech', ...headers },
       body: typeof body === 'string' ? body : JSON.stringify(body),
     },
     env
@@ -70,13 +88,14 @@ const post = (body: unknown, env: Env, headers: Record<string, string> = {}) =>
 
 describe('POST /v1/contact', () => {
   it('accepts a valid submission, persists it, and emails the owner', async () => {
-    const { env, sqls, inserts, emails } = makeEnv()
+    const { env, sqls, inserts } = makeEnv()
+    const urls = stubFetch()
     const res = await post(valid, env)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ ok: true })
     expect(inserts).toHaveLength(1)
     expect(inserts[0]).toContain('ada@example.com')
-    expect(emails).toHaveLength(1)
+    expect(urls.some((u) => u.includes('api.resend.com'))).toBe(true)
     // Writes into the current month's partition, creating it first.
     const table = monthTableName(Date.now())
     expect(sqls.some((s) => s.includes(`CREATE TABLE IF NOT EXISTS ${table}`))).toBe(true)
@@ -93,7 +112,8 @@ describe('POST /v1/contact', () => {
   })
 
   it('still succeeds when the email notification fails', async () => {
-    const { env, inserts } = makeEnv('fax', true)
+    const { env, inserts } = makeEnv()
+    stubFetch({ emailOk: false })
     const res = await post(valid, env)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ ok: true })
@@ -168,19 +188,9 @@ describe('POST /v1/contact', () => {
 })
 
 describe('POST /v1/contact — Turnstile captcha', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
-  const stubVerify = (success: boolean) =>
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => new Response(JSON.stringify({ success })))
-    )
-
   it('verifies the token and proceeds when verification succeeds', async () => {
-    stubVerify(true)
-    const { env, inserts } = makeEnv('fax', false, 'secret')
+    stubFetch({ turnstileOk: true })
+    const { env, inserts } = makeEnv('fax', 'secret')
     const res = await post({ ...valid, turnstileToken: 'good' }, env)
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ ok: true })
@@ -188,8 +198,8 @@ describe('POST /v1/contact — Turnstile captcha', () => {
   })
 
   it('rejects with 403 when verification fails', async () => {
-    stubVerify(false)
-    const { env, inserts } = makeEnv('fax', false, 'secret')
+    stubFetch({ turnstileOk: false })
+    const { env, inserts } = makeEnv('fax', 'secret')
     const res = await post({ ...valid, turnstileToken: 'bad' }, env)
     expect(res.status).toBe(403)
     expect(await res.json()).toEqual({ ok: false, error: 'Captcha verification failed' })
@@ -197,26 +207,27 @@ describe('POST /v1/contact — Turnstile captcha', () => {
   })
 
   it('rejects with 403 when the token is missing', async () => {
-    const { env, inserts } = makeEnv('fax', false, 'secret')
+    const { env, inserts } = makeEnv('fax', 'secret')
     const res = await post(valid, env)
     expect(res.status).toBe(403)
     expect(inserts).toHaveLength(0)
   })
-})
 
-describe('POST /v1/contact — rate limit', () => {
-  it('rejects with 429 when the per-IP limit is exceeded', async () => {
-    const { env, inserts } = makeEnv('fax', false, '', false)
-    const res = await post(valid, env, { 'cf-connecting-ip': '203.0.113.7' })
-    expect(res.status).toBe(429)
-    expect(await res.json()).toEqual({ ok: false, error: 'Too many requests' })
-    expect(inserts).toHaveLength(0)
-  })
-
-  it('proceeds when under the rate limit', async () => {
-    const { env, inserts } = makeEnv('fax', false, '', true)
-    const res = await post(valid, env, { 'cf-connecting-ip': '203.0.113.7' })
+  it('proceeds when the token is solved on a configured hostname', async () => {
+    stubFetch({ turnstileOk: true, hostname: 'soroush.tech' })
+    const { env, inserts } = makeEnv('fax', 'secret')
+    env.TURNSTILE_HOSTNAME = 'soroush.tech,www.soroush.tech'
+    const res = await post({ ...valid, turnstileToken: 'good' }, env)
     expect(res.status).toBe(200)
     expect(inserts).toHaveLength(1)
+  })
+
+  it('rejects a token solved on a non-configured hostname', async () => {
+    stubFetch({ turnstileOk: true, hostname: 'evil.example' })
+    const { env, inserts } = makeEnv('fax', 'secret')
+    env.TURNSTILE_HOSTNAME = 'soroush.tech,www.soroush.tech'
+    const res = await post({ ...valid, turnstileToken: 'good' }, env)
+    expect(res.status).toBe(403)
+    expect(inserts).toHaveLength(0)
   })
 })

--- a/workers/api/src/routes/contact.test.ts
+++ b/workers/api/src/routes/contact.test.ts
@@ -92,8 +92,13 @@ describe('POST /v1/contact', () => {
     const urls = stubFetch()
     const res = await post(valid, env)
     expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ ok: true })
+    const json = (await res.json()) as { ok: boolean; id: string }
+    expect(json.ok).toBe(true)
+    // A REQ-YYMM-XXXXXXXX reference is returned, derived from the stored UUID bound into the INSERT.
+    expect(json.id).toMatch(/^REQ-\d{4}-[0-9A-F]{8}$/)
     expect(inserts).toHaveLength(1)
+    const storedId = inserts[0][0] as string
+    expect(json.id.endsWith(storedId.slice(0, 8).toUpperCase())).toBe(true)
     expect(inserts[0]).toContain('ada@example.com')
     expect(urls.some((u) => u.includes('api.resend.com'))).toBe(true)
     // Writes into the current month's partition, creating it first.
@@ -116,7 +121,7 @@ describe('POST /v1/contact', () => {
     stubFetch({ emailOk: false })
     const res = await post(valid, env)
     expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ ok: true })
+    expect((await res.json()) as { ok: boolean }).toMatchObject({ ok: true })
     expect(inserts).toHaveLength(1)
   })
 
@@ -193,7 +198,7 @@ describe('POST /v1/contact — Turnstile captcha', () => {
     const { env, inserts } = makeEnv('fax', 'secret')
     const res = await post({ ...valid, turnstileToken: 'good' }, env)
     expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ ok: true })
+    expect((await res.json()) as { ok: boolean }).toMatchObject({ ok: true })
     expect(inserts).toHaveLength(1)
   })
 

--- a/workers/api/src/routes/contact.ts
+++ b/workers/api/src/routes/contact.ts
@@ -12,14 +12,6 @@ const MAX_BODY_BYTES = 16 * 1024
 export const contactRoute = new Hono<{ Bindings: Env }>()
 
 contactRoute.post('/contact', async (c) => {
-  // Per-IP rate limit (1 req / 60s). `cf-connecting-ip` is always set behind Cloudflare; it's
-  // absent only in local dev / direct access, where we skip rather than block.
-  const ip = c.req.header('cf-connecting-ip')
-  if (ip) {
-    const { success } = await c.env.RATE_LIMITER.limit({ key: ip })
-    if (!success) return c.json({ ok: false, error: 'Too many requests' }, 429)
-  }
-
   if (Number(c.req.header('content-length') ?? '0') > MAX_BODY_BYTES) {
     return c.json({ ok: false, error: 'Payload too large' }, 413)
   }
@@ -47,7 +39,11 @@ contactRoute.post('/contact', async (c) => {
     let passed = false
     if (typeof token === 'string') {
       const ip = c.req.header('cf-connecting-ip')
-      passed = await verifyTurnstile(c.env.TURNSTILE_SECRET, token, ip)
+      const hostnames = (c.env.TURNSTILE_HOSTNAME ?? '')
+        .split(',')
+        .map((h) => h.trim())
+        .filter(Boolean)
+      passed = await verifyTurnstile(c.env.TURNSTILE_SECRET, token, ip, hostnames)
     }
     if (!passed) {
       return c.json({ ok: false, error: 'Captcha verification failed' }, 403)

--- a/workers/api/src/routes/contact.ts
+++ b/workers/api/src/routes/contact.ts
@@ -5,6 +5,7 @@ import { notify } from 'src/services/email'
 import { verifyTurnstile } from 'src/services/turnstile'
 import { monthTableName, createTableStatement } from 'src/utils/tables'
 import { sanitizeContact } from 'src/utils/sanitize'
+import { formatRequestId } from 'src/utils/requestId'
 
 /** Reject bodies larger than this many bytes before parsing — a cheap abuse guard. */
 const MAX_BODY_BYTES = 16 * 1024
@@ -67,6 +68,7 @@ contactRoute.post('/contact', async (c) => {
   // next month, but create-if-not-exists here covers the first write of a month either way.
   const now = new Date()
   const table = monthTableName(now)
+  const id = crypto.randomUUID()
   await c.env.DB.prepare(createTableStatement(table)).run()
   await c.env.DB.prepare(
     `INSERT INTO ${table}
@@ -74,7 +76,7 @@ contactRoute.post('/contact', async (c) => {
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   )
     .bind(
-      crypto.randomUUID(),
+      id,
       now.toISOString(),
       v.name,
       v.company,
@@ -98,5 +100,6 @@ contactRoute.post('/contact', async (c) => {
     // swallow — the row is stored; the notification can be recovered from D1 if needed.
   }
 
-  return c.json({ ok: true })
+  // Return a short reference derived from the stored id so the user can quote it in follow-ups.
+  return c.json({ ok: true, id: formatRequestId(id, now) })
 })

--- a/workers/api/src/services/email.test.ts
+++ b/workers/api/src/services/email.test.ts
@@ -1,8 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { notify } from './email'
 import type { Env } from 'src/env'
-
-type Message = Parameters<Env['EMAIL']['send']>[0]
 
 const values = {
   name: 'Ada Lovelace',
@@ -16,58 +14,68 @@ const values = {
   message: 'Hello there.',
 }
 
+const env = { RESEND_API_KEY: 'test-key' } as unknown as Env
+
+/** Stub global fetch with the given response shape and return the mock for assertions. */
+const stubFetch = (impl: () => Partial<Response>) => {
+  const mock = vi.fn(async () => impl() as Response)
+  vi.stubGlobal('fetch', mock)
+  return mock
+}
+
+/** Parse the JSON body of the first fetch call. */
+const sentBody = (mock: ReturnType<typeof stubFetch>) =>
+  JSON.parse((mock.mock.calls[0][1] as RequestInit).body as string)
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
 describe('notify', () => {
-  it('sends to the owner with the submitter as reply-to', async () => {
-    let sent: Message | undefined
-    const env = {
-      EMAIL: {
-        send: async (message: Message) => {
-          sent = message
-        },
-      },
-    } as unknown as Env
+  it('POSTs to Resend with the owner as recipient and the submitter as reply-to', async () => {
+    const mock = stubFetch(() => ({ ok: true, status: 200 }))
 
     await notify(env, values)
 
-    expect(sent?.to).toBe('masoud@soroush.tech')
-    expect(sent?.from.email).toBe('contact@soroush.tech')
-    expect(sent?.replyTo).toBe('ada@example.com')
-    expect(sent?.subject).toBe('New inquiry: Project inquiry')
-    expect(sent?.text).toContain('ada@example.com')
-    expect(sent?.html).toContain('Hello there.')
+    expect(mock).toHaveBeenCalledTimes(1)
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.resend.com/emails')
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>).authorization).toBe('Bearer test-key')
+
+    const body = sentBody(mock)
+    expect(body.to).toEqual(['masoud@soroush.tech'])
+    expect(body.from).toContain('contact@soroush.tech')
+    expect(body.reply_to).toBe('ada@example.com')
+    expect(body.subject).toBe('New inquiry: Project inquiry')
+    expect(body.text).toContain('ada@example.com')
+    expect(body.html).toContain('Hello there.')
   })
 
   it('HTML-escapes submitted values so markup cannot be injected into the email body', async () => {
-    let sent: Message | undefined
-    const env = {
-      EMAIL: {
-        send: async (message: Message) => {
-          sent = message
-        },
-      },
-    } as unknown as Env
+    const mock = stubFetch(() => ({ ok: true, status: 200 }))
 
     await notify(env, { ...values, message: '<script>alert(1)</script>', name: 'a<b>&"\'' })
 
-    expect(sent?.html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
-    expect(sent?.html).toContain('a&lt;b&gt;&amp;&quot;&#39;')
-    expect(sent?.html).not.toContain('<script>')
+    const body = sentBody(mock)
+    expect(body.html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(body.html).toContain('a&lt;b&gt;&amp;&quot;&#39;')
+    expect(body.html).not.toContain('<script>')
     // The plain-text part keeps the original characters.
-    expect(sent?.text).toContain('<script>alert(1)</script>')
+    expect(body.text).toContain('<script>alert(1)</script>')
   })
 
   it('collapses newlines in the subject to prevent header injection', async () => {
-    let sent: Message | undefined
-    const env = {
-      EMAIL: {
-        send: async (message: Message) => {
-          sent = message
-        },
-      },
-    } as unknown as Env
+    const mock = stubFetch(() => ({ ok: true, status: 200 }))
 
     await notify(env, { ...values, subject: 'Hi\r\nBcc: evil@example.com' })
 
-    expect(sent?.subject).toBe('New inquiry: Hi Bcc: evil@example.com')
+    expect(sentBody(mock).subject).toBe('New inquiry: Hi Bcc: evil@example.com')
+  })
+
+  it('throws when Resend responds with a non-2xx status', async () => {
+    stubFetch(() => ({ ok: false, status: 422 }))
+
+    await expect(notify(env, values)).rejects.toThrow('Resend send failed: 422')
   })
 })

--- a/workers/api/src/services/email.ts
+++ b/workers/api/src/services/email.ts
@@ -1,8 +1,9 @@
 import type { contact } from '@soroush.tech/schema'
 import type { Env } from 'src/env'
 
-const FROM = { email: 'contact@soroush.tech', name: 'Soroush.tech' }
+const FROM = 'Soroush.tech <contact@soroush.tech>'
 const TO = 'masoud@soroush.tech'
+const RESEND_ENDPOINT = 'https://api.resend.com/emails'
 
 /** Escape HTML-significant characters so submitted text can't inject markup into the email. */
 const escapeHtml = (value: string): string =>
@@ -14,8 +15,9 @@ const escapeHtml = (value: string): string =>
     .replace(/'/g, '&#39;')
 
 /**
- * Notify the owner of a new contact submission via the Cloudflare Email Sending binding.
- * `replyTo` is set to the submitter so a reply in the mailbox goes straight back to them.
+ * Notify the owner of a new contact submission via the Resend HTTP API. `reply_to` is set to the
+ * submitter so a reply in the mailbox goes straight back to them. Throws on a non-2xx response so
+ * the caller (best-effort) can log it without the stored submission being affected.
  */
 export const notify = async (env: Env, values: contact.Values): Promise<void> => {
   const text = [
@@ -32,13 +34,24 @@ export const notify = async (env: Env, values: contact.Values): Promise<void> =>
     .filter(Boolean)
     .join('\n')
 
-  await env.EMAIL.send({
-    to: TO,
-    from: FROM,
-    replyTo: values.email,
-    // Collapse CR/LF so a crafted subject can't inject extra email headers.
-    subject: `New inquiry: ${values.subject}`.replace(/[\r\n]+/g, ' '),
-    text,
-    html: `<pre>${escapeHtml(text)}</pre>`,
+  const response = await fetch(RESEND_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${env.RESEND_API_KEY}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: FROM,
+      to: [TO],
+      reply_to: values.email,
+      // Collapse CR/LF so a crafted subject can't inject extra email headers.
+      subject: `New inquiry: ${values.subject}`.replace(/[\r\n]+/g, ' '),
+      text,
+      html: `<pre>${escapeHtml(text)}</pre>`,
+    }),
   })
+
+  if (!response.ok) {
+    throw new Error(`Resend send failed: ${response.status}`)
+  }
 }

--- a/workers/api/src/services/turnstile.test.ts
+++ b/workers/api/src/services/turnstile.test.ts
@@ -47,4 +47,23 @@ describe('verifyTurnstile', () => {
     stubFetch({})
     expect(await verifyTurnstile('the-secret', 'the-token')).toBe(false)
   })
+
+  it('returns true when the attested hostname is allowed', async () => {
+    stubFetch({ success: true, hostname: 'soroush.tech' })
+    expect(await verifyTurnstile('the-secret', 'the-token', undefined, ['soroush.tech'])).toBe(true)
+  })
+
+  it('returns false when the attested hostname is not allowed', async () => {
+    stubFetch({ success: true, hostname: 'evil.example' })
+    expect(await verifyTurnstile('the-secret', 'the-token', undefined, ['soroush.tech'])).toBe(
+      false
+    )
+  })
+
+  it('returns false when the hostname is absent but a list is required', async () => {
+    stubFetch({ success: true })
+    expect(await verifyTurnstile('the-secret', 'the-token', undefined, ['soroush.tech'])).toBe(
+      false
+    )
+  })
 })

--- a/workers/api/src/services/turnstile.ts
+++ b/workers/api/src/services/turnstile.ts
@@ -1,13 +1,16 @@
 const SITEVERIFY = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
 
 /**
- * Verify a Cloudflare Turnstile token against the siteverify endpoint. Returns true only on
- * an explicit `success`. `remoteip` is optional (the visitor's IP, when available).
+ * Verify a Cloudflare Turnstile token against the siteverify endpoint. Returns true only on an
+ * explicit `success` and, when `allowedHostnames` is non-empty, only if the siteverify-attested
+ * `hostname` (the domain the token was solved on — not client-supplied, so unspoofable) is in it.
+ * `remoteip` is optional (the visitor's IP, when available).
  */
 export const verifyTurnstile = async (
   secret: string,
   token: string,
-  remoteip?: string
+  remoteip?: string,
+  allowedHostnames: string[] = []
 ): Promise<boolean> => {
   const body = new FormData()
   body.append('secret', secret)
@@ -15,6 +18,8 @@ export const verifyTurnstile = async (
   if (remoteip) body.append('remoteip', remoteip)
 
   const res = await fetch(SITEVERIFY, { method: 'POST', body })
-  const data = (await res.json()) as { success?: boolean }
-  return data.success === true
+  const data = (await res.json()) as { success?: boolean; hostname?: string }
+  if (data.success !== true) return false
+  if (allowedHostnames.length > 0 && !allowedHostnames.includes(data.hostname ?? '')) return false
+  return true
 }

--- a/workers/api/src/utils/requestId.test.ts
+++ b/workers/api/src/utils/requestId.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { formatRequestId } from 'src/utils/requestId'
 
 describe('formatRequestId', () => {
-  it('formats the first 8 hex chars of a UUID, uppercased', () => {
-    expect(formatRequestId('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe('REQ-F47AC10B')
+  it('formats REQ-YYMM- plus the first 8 hex chars of a UUID, uppercased (UTC)', () => {
+    const when = new Date('2026-06-15T12:00:00Z')
+    expect(formatRequestId('f47ac10b-58cc-4372-a567-0e02b2c3d479', when)).toBe('REQ-2606-F47AC10B')
   })
 })

--- a/workers/api/src/utils/requestId.test.ts
+++ b/workers/api/src/utils/requestId.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import { formatRequestId } from 'src/utils/requestId'
+
+describe('formatRequestId', () => {
+  it('formats the first 8 hex chars of a UUID, uppercased', () => {
+    expect(formatRequestId('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe('REQ-F47AC10B')
+  })
+})

--- a/workers/api/src/utils/requestId.ts
+++ b/workers/api/src/utils/requestId.ts
@@ -1,0 +1,6 @@
+/**
+ * Display reference returned to the client for a stored submission: the first 8 hex chars of the
+ * UUID, uppercased, e.g. `REQ-F47AC10B`. Short enough to quote in a follow-up; the owner looks it
+ * up with `WHERE id LIKE 'f47ac10b%'`.
+ */
+export const formatRequestId = (id: string): string => `REQ-${id.slice(0, 8).toUpperCase()}`

--- a/workers/api/src/utils/requestId.ts
+++ b/workers/api/src/utils/requestId.ts
@@ -1,6 +1,11 @@
 /**
- * Display reference returned to the client for a stored submission: the first 8 hex chars of the
- * UUID, uppercased, e.g. `REQ-F47AC10B`. Short enough to quote in a follow-up; the owner looks it
- * up with `WHERE id LIKE 'f47ac10b%'`.
+ * Display reference returned to the client for a stored submission: `REQ-YYMM-XXXXXXXX` — the last
+ * two digits of the UTC year, the UTC month, and the first 8 hex chars of the UUID (uppercased),
+ * e.g. `REQ-2606-F47AC10B`. The YYMM points at the month partition (contacts_YYYY_MM); the owner
+ * looks the row up with `WHERE id LIKE 'f47ac10b%'`.
  */
-export const formatRequestId = (id: string): string => `REQ-${id.slice(0, 8).toUpperCase()}`
+export const formatRequestId = (id: string, when: Date): string => {
+  const yy = String(when.getUTCFullYear()).slice(-2)
+  const mm = String(when.getUTCMonth() + 1).padStart(2, '0')
+  return `REQ-${yy}${mm}-${id.slice(0, 8).toUpperCase()}`
+}


### PR DESCRIPTION
## Summary

Builds on the merged contact feature (#160). Three themes:

### 🔎 SEO

- **Fix non-indexing** — GitHub Pages 301-redirects `/about` → `/about/`, so the
  non-slashed canonical and sitemap URLs Google fetched all resolved through a
  redirect and were dropped from the index. `buildHead` and
  `@soroush.tech/vite-plugin-sitemap` now emit trailing-slash URLs.
- **Per-page metadata system** — new `src/renderer/head.ts` (`MetaTag`/`HeadMeta`
  types + `socialMeta`/`pageSocialMeta` helpers). `buildHead` now renders only the
  mechanical tags (title, canonical, og:url, og:site_name, CSP, referrer, robots);
  every page declares its own SEO via `+data`. Home/about/domain ship a
  fingerprinted `og:image` with real width/height (from imagetools); article pages
  emit `og:type=article`, `article:*` tags, and BlogPosting JSON-LD (the sitemap
  still reads `article:modified_time`). Twitter card tags completed.
- Header logo imported from `src/assets` so it is fingerprinted (was an unhashed
  `/soroush.svg` preload).

### 🧰 Onboarding

- A fresh clone is now runnable without manual env setup. `prepare` (run on
  `pnpm install`) also runs each workspace's `setup` via a root
  `postprepare`/`setup` → `pnpm -r run setup`:
  - `apps/web` copies `default.env` → `.env.local`
  - `workers/api` copies `default.env` → `.env` (`config:gen` still renders
    `wrangler.json` on `predev`/`predeploy`)
- Both copies are **create-if-missing** and **skipped in CI** (CD injects env via
  the ambient environment). Documented in the root, `apps/web`, and `workers`
  READMEs.

### 🛡️ Contact hardening (post-#160)

- **API** — send contact emails via the Resend HTTP API; guard request origin,
  verify the Turnstile hostname, and rate-limit all routes.
- **Web** — surface a submission reference (`REQ-YYMM-XXXXXXXX`) on the success
  panel; reword the CTA to "Contact Now"; allow Turnstile + the Worker API in the
  CSP.

## Testing

- `pnpm -r test` green across all workspaces (web 1719 tests + packages + worker).
- 100% coverage maintained on touched files.
- Production build verified: trailing-slash canonical/sitemap, per-page `og:image`
  with dimensions, article namespace + JSON-LD.

## Commits

- `f62eaf0` chore: bootstrap per-workspace local env on install
- `3ac90f7` test(web): cover the unset-honeypot branch in ContactInquire
- `2c28943` feat(web): drive per-page SEO metadata from +data
- `d5bd098` fix(seo): emit trailing-slash canonical and sitemap URLs
- `f56bc45` feat(web): show a submission reference on the contact success panel
- `d631729` chore(web): reword the contact CTA button to "Contact Now"
- `4f251c6` feat(api): guard origin, verify Turnstile hostname, rate-limit all routes
- `e116fdf` feat(api): send contact emails via the Resend HTTP API
- `2441de1` fix(web): allow Turnstile and the Worker API in the CSP

Closes #161, #162
