### PR TITLE
CI/CD deploy gating, Playwright caching, and Codecov coverage fixes

### DIFF
--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -15,8 +15,36 @@ concurrency:
   group: 'pages'
   cancel-in-progress: false
 jobs:
-  build:
+  changes:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+    outputs:
+      web: ${{ steps.read.outputs.web }}
+    steps:
+      - name: Download changed areas from CI
+        if: github.event_name == 'workflow_run'
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: changed-areas
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide whether to deploy
+        id: read
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ ! -f web.flag ]; then
+            echo "web=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "web=$(cat web.flag)" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     environment: github-pages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cd-worker-api.yml
+++ b/.github/workflows/cd-worker-api.yml
@@ -14,8 +14,36 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  changes:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+    outputs:
+      worker: ${{ steps.read.outputs.worker }}
+    steps:
+      - name: Download changed areas from CI
+        if: github.event_name == 'workflow_run'
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: changed-areas
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide whether to deploy
+        id: read
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ ! -f worker.flag ]; then
+            echo "worker=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "worker=$(cat worker.flag)" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    needs: changes
+    if: needs.changes.outputs.worker == 'true'
     runs-on: ubuntu-latest
     environment: cd-worker
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         run: ${{ needs.prepare.outputs.runner }} --filter ${{ matrix.filter }} test:coverage
 
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/${{ matrix.dir }}/coverage/lcov.info
@@ -237,7 +237,7 @@ jobs:
         run: ${{ needs.prepare.outputs.runner }} --filter @soroush/api test:coverage
 
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./workers/api/coverage/lcov.info
@@ -317,7 +317,7 @@ jobs:
 
       - name: Upload Unit Test Coverage
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./apps/web/coverage/lcov.info
@@ -331,7 +331,7 @@ jobs:
 
       - name: Upload Browser Test Coverage
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./apps/web/coverage/lcov.info
@@ -358,7 +358,7 @@ jobs:
 
       - name: Upload Coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./apps/web/coverage/lcov.info
@@ -386,7 +386,7 @@ jobs:
 
       - name: Upload E2E Coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./apps/web/coverage/e2e/lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,11 @@ jobs:
     environment: CI
     timeout-minutes: 30
 
+    # Pin the browser download location so one cache path/key works on every OS
+    # (the default location differs per platform: ~/.cache, ~/Library/Caches, AppData).
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/ms-playwright
+
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -278,7 +283,7 @@ jobs:
         uses: actions/cache/restore@v5
         id: playwright-cache
         with:
-          path: ~/.cache/ms-playwright
+          path: ${{ github.workspace }}/ms-playwright
           key: ${{ runner.os }}-playwright-${{ needs.prepare.outputs.playwright_version }}
 
       - name: Install dependencies
@@ -293,7 +298,7 @@ jobs:
         if: always() && steps.playwright-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
-          path: ~/.cache/ms-playwright
+          path: ${{ github.workspace }}/ms-playwright
           key: ${{ runner.os }}-playwright-${{ needs.prepare.outputs.playwright_version }}
 
       - name: Build project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,23 @@ jobs:
           console.log(`has_packages=${include.length ? 'true' : 'false'}`)
           NODE
 
+      # Publish the changed-area flags so the workflow_run-triggered CD workflows
+      # can gate their deploys on what actually changed. workflow_run events carry
+      # no diff base of their own, so they read the answer this push-event run
+      # already computed against github.event.before..after.
+      - name: Record changed areas
+        run: |
+          printf '%s' '${{ steps.filter.outputs.worker }}' > worker.flag
+          printf '%s' '${{ steps.filter.outputs.web }}' > web.flag
+
+      - name: Upload changed areas
+        uses: actions/upload-artifact@v7
+        with:
+          name: changed-areas
+          path: |
+            worker.flag
+            web.flag
+
   # Lint + typecheck the whole workspace once (cheap, recursive).
   lint:
     needs: prepare

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -8,7 +8,7 @@ import prettierConfig from 'eslint-config-prettier'
  * Consumers layer their own environment/framework rules on top
  * (e.g. apps/web adds React, Storybook, and browser globals).
  */
-export default tseslint.config(
+const config = tseslint.config(
   { ignores: ['dist', 'build', 'coverage'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
@@ -38,3 +38,5 @@ export default tseslint.config(
     },
   }
 )
+
+export default config

--- a/packages/schema/vitest.config.ts
+++ b/packages/schema/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      include: ['src/contact.ts', 'src/index.ts'],
+      include: ['src/**/*.{js,ts,tsx,jsx}'],
       thresholds: { 100: true },
     },
   },

--- a/packages/vite-plugin-msw-server/vitest.config.ts
+++ b/packages/vite-plugin-msw-server/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      include: ['src/index.ts'],
+      include: ['src/**/*.{js,ts,tsx,jsx}'],
       thresholds: { 100: true },
     },
   },

--- a/packages/vite-plugin-sitemap/vitest.config.ts
+++ b/packages/vite-plugin-sitemap/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      include: ['src/index.ts'],
+      include: ['src/**/*.{js,ts,tsx,jsx}'],
       thresholds: { 100: true },
     },
   },

--- a/packages/vite-plugin-watch/vitest.config.ts
+++ b/packages/vite-plugin-watch/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      include: ['src/index.ts'],
+      include: ['src/**/*.{js,ts,tsx,jsx}'],
       thresholds: { 100: true },
     },
   },


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  Follow-up to #167. Hardens the unified CI/CD pipeline and fixes package coverage reporting to Codecov.                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  ### CI/CD                                                                                                                                                                                                                                                                                                         
  - **Gate deploys on changed areas** (`b6d950b`): `cd-web` / `cd-worker-api` previously redeployed on every successful CI run on `main`, even for an unchanged area (`workflow_run` events carry no diff base). CI's `prepare` job now records the web/worker change flags it already computes from                
  `github.event.before..after` and uploads them as a `changed-areas` artifact; each CD workflow downloads it from the triggering run and gates its deploy on the relevant flag. A missing artifact or a manual dispatch fails open and deploys.                                                                     
  - **Cache Playwright on every OS** (`d93d9f6`): the web job cached browsers at `~/.cache/ms-playwright`, which only exists on Linux, so macOS/Windows always missed the restore and failed the save. Pin `PLAYWRIGHT_BROWSERS_PATH` to a fixed workspace folder so one cache path/key works on all three OSes.    
  - **Bump codecov-action to v7** (`7d8150a`): v5 bundled `actions/github-script` v7 (Node 20), which the runner now flags as deprecated and force-runs on Node 24. v7 switches the internal `github-script` to v8 (Node 24), clearing the warning. Inputs unchanged.                                               
                                                                                                                                                                                                                                                                                                                    
  ### Coverage                                                                                                                                                                                                                                                                                                      
  - **Fix eslint-config coverage** (`0a01c95`): `export default tseslint.config(...)` is a bare default-exported call expression, which produces no instrumentable statements under the v8 provider. eslint-config therefore uploaded an empty `0/0` lcov, so Codecov showed "No report uploaded". Binding the      
  config to a `const` before exporting makes it instrumentable → **100% (1/1)** with a real lcov.                                                                                                                                                                                                                   
  - **Widen include globs**: `schema`, `vite-plugin-watch`, `vite-plugin-sitemap`, and `vite-plugin-msw-server` now use `src/**/*.{js,ts,tsx,jsx}` (also drops a stray space in the brace list that matched a literal `␣jsx` extension).                                                                            
                                                                                                                                                                                                                                                                                                                    
  ### Docs                                                                                                                                                                                                                                                                                                          
  - `7e8dadb`: lint fix + minor commit-skill doc tweak.                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                    
  ## Testing                                                                                                                                                                                                                                                                                                        
  - `pnpm lint` and `pnpm typecheck` pass.                                                                                                                                                                                                                                                                          
  - `pnpm test:coverage` 100% on all touched packages: eslint-config 1/1, schema 5/5, vite-plugin-sitemap 26/26, vite-plugin-msw-server 11/11, vite-plugin-watch 17/17.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD deployment workflows with conditional gating based on detected changes.
  * Upgraded code coverage reporting tooling to the latest version.
  * Improved build caching performance for browser resources.
  * Expanded test coverage configuration to include all source files across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->