### PR TITLE
fix(seo): sync head meta tags on client-side navigation - close #23

### DIFF
--- a/apps/web/src/pages/articles/articles.e2e.ts
+++ b/apps/web/src/pages/articles/articles.e2e.ts
@@ -26,11 +26,19 @@ test('articles page lists the mocked gists and exposes its meta tags', async ({ 
 
 test('navigates from the articles list to an article via client routing', async ({ page }) => {
   await page.goto('/articles')
-  await waitForLoaded(page)
+  // Wait for hydration so Vike intercepts the click; the loader's `hidden` state alone can
+  // resolve before it ever mounts, letting the anchor do a full document navigation instead.
+  await page.waitForLoadState('networkidle')
+
+  // Tag the window so we can prove the navigation stayed client-side (no full reload).
+  await page.evaluate(() => ((window as Window & { __noReload?: boolean }).__noReload = true))
 
   await page.getByRole('link', { name: 'Mock Article Title' }).click()
 
   await expect(page).toHaveURL('/article/mock-gist-id')
+  expect(await page.evaluate(() => (window as Window & { __noReload?: boolean }).__noReload)).toBe(
+    true
+  )
   // Title is recomputed client-side on navigation (see +title / onRenderClient).
   await expect(page).toHaveTitle('Mock Article Title by Masoud Soroush · SOROUSH.TECH')
 })

--- a/apps/web/src/renderer/+config.ts
+++ b/apps/web/src/renderer/+config.ts
@@ -17,10 +17,10 @@ export const config = {
       },
     },
     description: {
-      env: { server: true },
+      env: { server: true, client: true },
     },
     robots: {
-      env: { server: true },
+      env: { server: true, client: true },
     },
     dataIsomorph: {
       env: { config: true },

--- a/apps/web/src/renderer/+onRenderClient.test.tsx
+++ b/apps/web/src/renderer/+onRenderClient.test.tsx
@@ -28,6 +28,7 @@ describe('+onRenderClient', () => {
 
   afterEach(() => {
     document.body.removeChild(container)
+    document.head.querySelectorAll('[data-mh]').forEach((el) => el.remove())
   })
 
   it('hydration: calls hydrateRoot and initMSW on first call', async () => {
@@ -42,9 +43,16 @@ describe('+onRenderClient', () => {
     expect(createRoot).toHaveBeenCalledWith(container)
   })
 
-  it('non-hydration: updates document.title from the page config', async () => {
-    await onRenderClient({ isHydration: false, config: { title: 'About' } } as never)
+  it('non-hydration: syncs the head tags from the page config', async () => {
+    await onRenderClient({
+      isHydration: false,
+      config: { title: 'About', description: 'Who I am.' },
+      urlPathname: '/about',
+    } as never)
     expect(document.title).toBe('About · SOROUSH.TECH')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Who I am.'
+    )
   })
 
   it('non-hydration: skips createRoot and initMSW on subsequent CSR calls', async () => {

--- a/apps/web/src/renderer/+onRenderClient.tsx
+++ b/apps/web/src/renderer/+onRenderClient.tsx
@@ -2,7 +2,7 @@ import { createRoot, hydrateRoot, type Root } from 'react-dom/client'
 import type { OnRenderClientAsync } from 'vike/types'
 import { initMSW } from 'src/utils'
 import { Bootstrap } from 'src/common/Bootstrap'
-import { documentTitle } from './seo'
+import { applyHead } from './buildHead'
 
 let root: Root
 export const onRenderClient: OnRenderClientAsync = async (
@@ -20,8 +20,8 @@ export const onRenderClient: OnRenderClientAsync = async (
       root = createRoot(container)
     }
     root.render(page)
-    // SSR sets the title on first paint; update it on client-side navigation.
-    document.title = documentTitle(pageContext)
+    // SSR sets the head tags on first paint; sync them on client-side navigation.
+    applyHead(pageContext)
   } else {
     root = hydrateRoot(container, page)
   }

--- a/apps/web/src/renderer/+onRenderHtml.test.tsx
+++ b/apps/web/src/renderer/+onRenderHtml.test.tsx
@@ -60,7 +60,7 @@ describe('+onRenderHtml', () => {
 
   it('injects the default site title when there is no page meta', async () => {
     const result = (await onRenderHtml({} as never)) as unknown as { __html: string }
-    expect(result.__html).toContain('<title>SOROUSH.TECH</title>')
+    expect(result.__html).toContain('<title data-mh>SOROUSH.TECH</title>')
   })
 
   it('injects page SEO meta from pageContext config and url', async () => {
@@ -69,7 +69,9 @@ describe('+onRenderHtml', () => {
       urlPathname: '/about',
     }
     const result = (await onRenderHtml(pageContext as never)) as unknown as { __html: string }
-    expect(result.__html).toContain('<title>About · SOROUSH.TECH</title>')
-    expect(result.__html).toContain('<link rel="canonical" href="https://soroush.tech/about/" />')
+    expect(result.__html).toContain('<title data-mh>About · SOROUSH.TECH</title>')
+    expect(result.__html).toContain(
+      '<link rel="canonical" href="https://soroush.tech/about/" data-mh />'
+    )
   })
 })

--- a/apps/web/src/renderer/buildHead.test.ts
+++ b/apps/web/src/renderer/buildHead.test.ts
@@ -100,6 +100,24 @@ describe('buildHead', () => {
     })
   })
 
+  describe('malformed page-owned meta is skipped', () => {
+    it('drops entries that are not a valid name/property + string-content tag', () => {
+      const head = buildHead(
+        ctx(undefined, '/x', {
+          meta: [
+            { name: 'description', content: 'kept' },
+            { name: 'broken', content: 42 },
+            { content: 'no key' },
+            null,
+          ],
+        })
+      )
+      expect(head).toContain('<meta name="description" content="kept" data-mh />')
+      expect(head).not.toContain('broken')
+      expect(head).not.toContain('no key')
+    })
+  })
+
   describe('jsonLd from data', () => {
     it('renders a script tag and neutralizes a </script> sequence', () => {
       const head = buildHead(

--- a/apps/web/src/renderer/buildHead.test.ts
+++ b/apps/web/src/renderer/buildHead.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import type { PageContext } from 'vike/types'
-import { buildHead } from './buildHead'
+import { buildHead, applyHead } from './buildHead'
 
 const ctx = (config?: unknown, urlPathname?: string, data?: unknown) =>
   ({ config, urlPathname, data }) as unknown as PageContext
@@ -10,18 +10,20 @@ describe('buildHead', () => {
     const head = buildHead(ctx())
 
     it('falls back to the site title', () => {
-      expect(head).toContain('<title>SOROUSH.TECH</title>')
+      expect(head).toContain('<title data-mh>SOROUSH.TECH</title>')
     })
 
     it('defaults robots to index,follow', () => {
-      expect(head).toContain('<meta name="robots" content="index,follow" />')
+      expect(head).toContain('<meta name="robots" content="index,follow" data-mh />')
     })
 
     it('emits canonical, og:url, og:site_name, and referrer', () => {
-      expect(head).toContain('<link rel="canonical" href="https://soroush.tech/" />')
-      expect(head).toContain('<meta property="og:url" content="https://soroush.tech/" />')
-      expect(head).toContain('<meta property="og:site_name" content="SOROUSH.TECH" />')
-      expect(head).toContain('<meta name="referrer" content="strict-origin-when-cross-origin" />')
+      expect(head).toContain('<link rel="canonical" href="https://soroush.tech/" data-mh />')
+      expect(head).toContain('<meta property="og:url" content="https://soroush.tech/" data-mh />')
+      expect(head).toContain('<meta property="og:site_name" content="SOROUSH.TECH" data-mh />')
+      expect(head).toContain(
+        '<meta name="referrer" content="strict-origin-when-cross-origin" data-mh />'
+      )
     })
 
     it('omits page-owned tags when there is no data', () => {
@@ -32,18 +34,20 @@ describe('buildHead', () => {
 
   describe('title + robots from config', () => {
     it('renders a suffixed document title', () => {
-      expect(buildHead(ctx({ title: 'About' }))).toContain('<title>About · SOROUSH.TECH</title>')
+      expect(buildHead(ctx({ title: 'About' }))).toContain(
+        '<title data-mh>About · SOROUSH.TECH</title>'
+      )
     })
 
     it('resolves a function title', () => {
       expect(buildHead(ctx({ title: () => 'Dynamic' }))).toContain(
-        '<title>Dynamic · SOROUSH.TECH</title>'
+        '<title data-mh>Dynamic · SOROUSH.TECH</title>'
       )
     })
 
     it('emits a noindex directive when configured', () => {
       expect(buildHead(ctx({ robots: 'noindex,nofollow' }))).toContain(
-        '<meta name="robots" content="noindex,nofollow" />'
+        '<meta name="robots" content="noindex,nofollow" data-mh />'
       )
     })
   })
@@ -51,13 +55,13 @@ describe('buildHead', () => {
   describe('meta description from config', () => {
     it('renders the page description', () => {
       expect(buildHead(ctx({ description: 'Who I am.' }))).toContain(
-        '<meta name="description" content="Who I am." />'
+        '<meta name="description" content="Who I am." data-mh />'
       )
     })
 
     it('resolves a function description (e.g. the article +description hook)', () => {
       expect(buildHead(ctx({ description: () => 'A summary. - Masoud Soroush' }))).toContain(
-        '<meta name="description" content="A summary. - Masoud Soroush" />'
+        '<meta name="description" content="A summary. - Masoud Soroush" data-mh />'
       )
     })
 
@@ -73,8 +77,10 @@ describe('buildHead', () => {
 
     it('appends a trailing slash to other paths', () => {
       const head = buildHead(ctx(undefined, '/about'))
-      expect(head).toContain('<link rel="canonical" href="https://soroush.tech/about/" />')
-      expect(head).toContain('<meta property="og:url" content="https://soroush.tech/about/" />')
+      expect(head).toContain('<link rel="canonical" href="https://soroush.tech/about/" data-mh />')
+      expect(head).toContain(
+        '<meta property="og:url" content="https://soroush.tech/about/" data-mh />'
+      )
     })
   })
 
@@ -89,8 +95,8 @@ describe('buildHead', () => {
     )
 
     it('renders both name- and property-keyed meta tags', () => {
-      expect(head).toContain('<meta property="og:title" content="My OG Title" />')
-      expect(head).toContain('<meta name="twitter:card" content="summary_large_image" />')
+      expect(head).toContain('<meta property="og:title" content="My OG Title" data-mh />')
+      expect(head).toContain('<meta name="twitter:card" content="summary_large_image" data-mh />')
     })
   })
 
@@ -101,6 +107,7 @@ describe('buildHead', () => {
           jsonLd: { '@type': 'BlogPosting', headline: 'a </script> b' },
         })
       )
+      expect(head).toContain('<script type="application/ld+json" data-mh>')
       expect(head).toContain('"@type":"BlogPosting"')
       expect(head).toContain('\\u003c/script> b')
     })
@@ -117,7 +124,7 @@ describe('buildHead', () => {
   describe('escaping', () => {
     it('escapes the document title', () => {
       expect(buildHead(ctx({ title: 'A & B <x>' }))).toContain(
-        '<title>A &amp; B &lt;x&gt; · SOROUSH.TECH</title>'
+        '<title data-mh>A &amp; B &lt;x&gt; · SOROUSH.TECH</title>'
       )
     })
 
@@ -149,5 +156,59 @@ describe('buildHead', () => {
       expect(head).toContain("script-src 'self' https://challenges.cloudflare.com")
       expect(head).toContain('frame-src https://challenges.cloudflare.com')
     })
+  })
+})
+
+describe('applyHead', () => {
+  afterEach(() => {
+    document.head.querySelectorAll('[data-mh]').forEach((el) => el.remove())
+  })
+
+  it('applies the managed tags to document.head', () => {
+    applyHead(ctx({ title: 'About', description: 'Who I am.' }, '/about'))
+
+    expect(document.title).toBe('About · SOROUSH.TECH')
+    expect(document.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Who I am.'
+    )
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href')).toBe(
+      'https://soroush.tech/about/'
+    )
+    expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content')).toBe(
+      'https://soroush.tech/about/'
+    )
+    expect(document.querySelector('meta[name="robots"]')?.getAttribute('content')).toBe(
+      'index,follow'
+    )
+  })
+
+  it('renders page-owned meta and a JSON-LD script from data', () => {
+    applyHead(
+      ctx(undefined, '/article/x/', {
+        meta: [{ property: 'og:title', content: 'My OG Title' }],
+        jsonLd: { '@type': 'BlogPosting' },
+      })
+    )
+
+    expect(document.querySelector('meta[property="og:title"]')?.getAttribute('content')).toBe(
+      'My OG Title'
+    )
+    const script = document.querySelector('script[type="application/ld+json"]')
+    expect(script?.textContent).toBe('{"@type":"BlogPosting"}')
+  })
+
+  it('removes the previous page tags on re-apply (no stale tags, no duplicates)', () => {
+    applyHead(
+      ctx({ title: 'Article' }, '/article/x/', {
+        meta: [{ property: 'og:title', content: 'Old' }],
+        jsonLd: { '@type': 'BlogPosting' },
+      })
+    )
+    applyHead(ctx({ title: 'About', description: 'Who I am.' }, '/about'))
+
+    expect(document.querySelector('meta[property="og:title"]')).toBeNull()
+    expect(document.querySelector('script[type="application/ld+json"]')).toBeNull()
+    expect(document.querySelectorAll('title[data-mh]')).toHaveLength(1)
+    expect(document.title).toBe('About · SOROUSH.TECH')
   })
 })

--- a/apps/web/src/renderer/buildHead.ts
+++ b/apps/web/src/renderer/buildHead.ts
@@ -65,7 +65,8 @@ export const collectHeadTags = (pageContext: PageContext): HeadTag[] => {
     typeof pageContext.config?.robots === 'string' ? pageContext.config.robots : 'index,follow'
   // Trailing slash matches GitHub Pages, which 301-redirects `/about` -> `/about/`.
   const path = pageContext.urlPathname || '/'
-  const url = `${SITE_URL}${path.endsWith('/') ? path : `${path}/`}`
+  const slashedPath = path.endsWith('/') ? path : `${path}/`
+  const url = `${SITE_URL}${slashedPath}`
   const head = isHeadMeta(pageContext.data) ? pageContext.data : undefined
   // Canonical description from the page config, resolved the same way as the title
   // (article pages supply it via their +description hook). socialMeta owns og/twitter only.
@@ -92,7 +93,7 @@ const serialize = (tag: HeadTag): string => {
   if (tag.el === 'title') return `<title ${MARK}>${escape(tag.text)}</title>`
   if (tag.el === 'script')
     // < guards against a "</script>" sequence breaking out of the tag.
-    return `<script type="application/ld+json" ${MARK}>${JSON.stringify(tag.json).replace(/</g, '\\u003c')}</script>`
+    return `<script type="application/ld+json" ${MARK}>${JSON.stringify(tag.json).replaceAll('<', '\\u003c')}</script>`
   const attrs = Object.entries(tag.attrs)
     .map(([key, value]) => `${key}="${escape(value)}"`)
     .join(' ')

--- a/apps/web/src/renderer/buildHead.ts
+++ b/apps/web/src/renderer/buildHead.ts
@@ -3,6 +3,15 @@ import { SITE_URL } from 'src/config'
 import type { HeadMeta, MetaTag } from './head'
 import { SITE_NAME, documentTitle, pageDescription } from './seo'
 
+/** Marks tags this module owns, so the client can remove the previous page's set on navigation. */
+const MARK = 'data-mh'
+
+/** A managed head tag, rendered to HTML on the server and to a DOM node on the client. */
+type HeadTag =
+  | { el: 'title'; text: string }
+  | { el: 'meta' | 'link'; attrs: Record<string, string> }
+  | { el: 'script'; json: object }
+
 /** Escapes a value for safe interpolation into HTML text and attribute contexts. */
 const escape = (value: string): string =>
   value
@@ -31,47 +40,96 @@ const CSP = [
   "form-action 'self'",
 ].join('; ')
 
-const metaTag = (tag: MetaTag): string =>
+const metaAttrs = (tag: MetaTag): Record<string, string> =>
   'name' in tag
-    ? `<meta name="${escape(tag.name)}" content="${escape(tag.content)}" />`
-    : `<meta property="${escape(tag.property)}" content="${escape(tag.content)}" />`
-
-const jsonLdScript = (data: object): string =>
-  // < guards against a "</script>" sequence breaking out of the tag.
-  `<script type="application/ld+json">${JSON.stringify(data).replace(/</g, '\\u003c')}</script>`
+    ? { name: tag.name, content: tag.content }
+    : { property: tag.property, content: tag.content }
 
 /**
- * Builds the per-page `<head>`: the mechanical/required tags (title, canonical, og:url, CSP,
- * referrer, robots, og:site_name) plus the page-owned tags from `+data.ts` (`HeadMeta.meta`
- * rendered generically, and `HeadMeta.jsonLd` as a script). Pages declare their SEO via `+data`.
+ * The managed `<head>` tags for a page: the mechanical/required tags (title, canonical, og:url,
+ * referrer, robots, og:site_name) plus the page-owned tags from `+data.ts` (`HeadMeta.meta` and
+ * `HeadMeta.jsonLd`). CSP is excluded — it's a parse-time, server-only concern. This single source
+ * of truth feeds both `buildHead` (server HTML) and `applyHead` (client DOM on navigation).
  */
-export const buildHead = (pageContext: PageContext): string => {
+export const collectHeadTags = (pageContext: PageContext): HeadTag[] => {
   const robots =
     typeof pageContext.config?.robots === 'string' ? pageContext.config.robots : 'index,follow'
   // Trailing slash matches GitHub Pages, which 301-redirects `/about` -> `/about/`.
   const path = pageContext.urlPathname || '/'
-  const url = escape(`${SITE_URL}${path.endsWith('/') ? path : `${path}/`}`)
+  const url = `${SITE_URL}${path.endsWith('/') ? path : `${path}/`}`
   const head = isHeadMeta(pageContext.data) ? pageContext.data : undefined
   // Canonical description from the page config, resolved the same way as the title
   // (article pages supply it via their +description hook). socialMeta owns og/twitter only.
   const description = pageDescription(pageContext)
 
-  const tags = [
-    `<title>${escape(documentTitle(pageContext))}</title>`,
+  const tags: HeadTag[] = [
+    { el: 'title', text: documentTitle(pageContext) },
+    { el: 'meta', attrs: { name: 'referrer', content: 'strict-origin-when-cross-origin' } },
+    { el: 'link', attrs: { rel: 'canonical', href: url } },
+    { el: 'meta', attrs: { property: 'og:url', content: url } },
+    { el: 'meta', attrs: { property: 'og:site_name', content: SITE_NAME } },
+    { el: 'meta', attrs: { name: 'robots', content: robots } },
+  ]
+  if (description) tags.push({ el: 'meta', attrs: { name: 'description', content: description } })
+  for (const tag of head?.meta ?? []) tags.push({ el: 'meta', attrs: metaAttrs(tag) })
+  if (head?.jsonLd) tags.push({ el: 'script', json: head.jsonLd })
+
+  return tags
+}
+
+/** Serializes a managed tag to an HTML string with the `data-mh` marker (server-side). */
+const serialize = (tag: HeadTag): string => {
+  if (tag.el === 'title') return `<title ${MARK}>${escape(tag.text)}</title>`
+  if (tag.el === 'script')
+    // < guards against a "</script>" sequence breaking out of the tag.
+    return `<script type="application/ld+json" ${MARK}>${JSON.stringify(tag.json).replace(/</g, '\\u003c')}</script>`
+  const attrs = Object.entries(tag.attrs)
+    .map(([key, value]) => `${key}="${escape(value)}"`)
+    .join(' ')
+  return `<${tag.el} ${attrs} ${MARK} />`
+}
+
+/**
+ * Builds the per-page `<head>` HTML: the server-only CSP meta (prod) plus the managed tags from
+ * `collectHeadTags`, each marked with `data-mh`. Injected by `+onRenderHtml`.
+ */
+export const buildHead = (pageContext: PageContext): string =>
+  [
     // Dev is skipped: Vite/React-refresh inject inline scripts that `script-src 'self'` would block.
     ...(import.meta.env.DEV
       ? []
       : [`<meta http-equiv="Content-Security-Policy" content="${CSP}" />`]),
-    `<meta name="referrer" content="strict-origin-when-cross-origin" />`,
-    `<link rel="canonical" href="${url}" />`,
-    `<meta property="og:url" content="${url}" />`,
-    `<meta property="og:site_name" content="${SITE_NAME}" />`,
-    `<meta name="robots" content="${escape(robots)}" />`,
-    ...(description ? [`<meta name="description" content="${escape(description)}" />`] : []),
-    ...(head?.meta ?? []).map(metaTag),
-  ]
+    ...collectHeadTags(pageContext).map(serialize),
+  ].join('\n    ')
 
-  if (head?.jsonLd) tags.push(jsonLdScript(head.jsonLd))
+/** Creates the DOM node for a managed tag (client-side). DOM APIs escape values natively. */
+const createElement = (tag: HeadTag): HTMLElement => {
+  if (tag.el === 'title') {
+    const el = document.createElement('title')
+    el.textContent = tag.text
+    return el
+  }
+  if (tag.el === 'script') {
+    const el = document.createElement('script')
+    el.setAttribute('type', 'application/ld+json')
+    el.textContent = JSON.stringify(tag.json)
+    return el
+  }
+  const el = document.createElement(tag.el)
+  for (const [key, value] of Object.entries(tag.attrs)) el.setAttribute(key, value)
+  return el
+}
 
-  return tags.join('\n    ')
+/**
+ * Syncs the managed `<head>` tags with the current page on client-side navigation: removes the
+ * previous page's `[data-mh]` tags, then re-emits this page's set. Keeps `document.title`,
+ * description, canonical, og/twitter, robots, and JSON-LD in sync after a client route change.
+ */
+export const applyHead = (pageContext: PageContext): void => {
+  document.head.querySelectorAll(`[${MARK}]`).forEach((el) => el.remove())
+  for (const tag of collectHeadTags(pageContext)) {
+    const el = createElement(tag)
+    el.setAttribute(MARK, '')
+    document.head.appendChild(el)
+  }
 }

--- a/apps/web/src/renderer/buildHead.ts
+++ b/apps/web/src/renderer/buildHead.ts
@@ -24,6 +24,15 @@ const escape = (value: string): string =>
 const isHeadMeta = (data: unknown): data is HeadMeta =>
   typeof data === 'object' && data !== null && ('meta' in data || 'jsonLd' in data)
 
+// `isHeadMeta` only proves `meta` exists, not that each entry is well-formed. Validate the
+// shape so a malformed payload is skipped rather than crashing `escape()` during serialization.
+const isMetaTag = (value: unknown): value is MetaTag => {
+  if (typeof value !== 'object' || value === null) return false
+  const tag = value as Record<string, unknown>
+  if (typeof tag.content !== 'string') return false
+  return typeof tag.name === 'string' || typeof tag.property === 'string'
+}
+
 // 'unsafe-inline' styles are required by Emotion's critical-CSS extraction;
 // *.githubusercontent.com covers avatars and gist-proxied images.
 // challenges.cloudflare.com loads the Turnstile script and renders its challenge
@@ -71,7 +80,8 @@ export const collectHeadTags = (pageContext: PageContext): HeadTag[] => {
     { el: 'meta', attrs: { name: 'robots', content: robots } },
   ]
   if (description) tags.push({ el: 'meta', attrs: { name: 'description', content: description } })
-  for (const tag of head?.meta ?? []) tags.push({ el: 'meta', attrs: metaAttrs(tag) })
+  for (const tag of head?.meta ?? [])
+    if (isMetaTag(tag)) tags.push({ el: 'meta', attrs: metaAttrs(tag) })
   if (head?.jsonLd) tags.push({ el: 'script', json: head.jsonLd })
 
   return tags

--- a/apps/web/src/renderer/buildHead.ts
+++ b/apps/web/src/renderer/buildHead.ts
@@ -93,7 +93,7 @@ const serialize = (tag: HeadTag): string => {
   if (tag.el === 'title') return `<title ${MARK}>${escape(tag.text)}</title>`
   if (tag.el === 'script')
     // < guards against a "</script>" sequence breaking out of the tag.
-    return `<script type="application/ld+json" ${MARK}>${JSON.stringify(tag.json).replaceAll('<', '\\u003c')}</script>`
+    return `<script type="application/ld+json" ${MARK}>${JSON.stringify(tag.json).replaceAll('<', String.raw`\u003c`)}</script>`
   const attrs = Object.entries(tag.attrs)
     .map(([key, value]) => `${key}="${escape(value)}"`)
     .join(' ')

--- a/apps/web/src/test/e2e/seo.e2e.ts
+++ b/apps/web/src/test/e2e/seo.e2e.ts
@@ -6,7 +6,7 @@ test('each page declares a self-referential https canonical URL', async ({ reque
   const home = await request.get('/')
   expect(home.status()).toBe(200)
   const homeHtml = await home.text()
-  expect(homeHtml).toContain('<link rel="canonical" href="https://soroush.tech/" />')
+  expect(homeHtml).toContain('<link rel="canonical" href="https://soroush.tech/" data-mh />')
   // Home maps to the portrait, so it carries an absolute og:image (asset URL differs
   // between the dev-server and prod-build runs, so match the prefix only).
   expect(homeHtml).toMatch(/<meta property="og:image" content="https:\/\/soroush\.tech\//)
@@ -14,8 +14,60 @@ test('each page declares a self-referential https canonical URL', async ({ reque
   const articles = await request.get('/articles')
   expect(articles.status()).toBe(200)
   expect(await articles.text()).toContain(
-    '<link rel="canonical" href="https://soroush.tech/articles/" />'
+    '<link rel="canonical" href="https://soroush.tech/articles/" data-mh />'
   )
+})
+
+test('syncs all head meta on client-side navigation (not just the title)', async ({ page }) => {
+  await page.goto('/articles')
+  // Wait for hydration so Vike's client router intercepts the click (otherwise the anchor
+  // does a full document navigation and we'd never exercise the client-side head sync).
+  await page.waitForLoadState('networkidle')
+
+  // Baseline: the articles list — a plain page with no article meta or JSON-LD.
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://soroush.tech/articles/'
+  )
+  await expect(page.locator('meta[property="og:type"]')).toHaveAttribute('content', 'website')
+  await expect(page.locator('script[type="application/ld+json"]')).toHaveCount(0)
+
+  // Tag the window so we can prove the navigation was client-side (no full document reload).
+  await page.evaluate(() => ((window as Window & { __noReload?: boolean }).__noReload = true))
+
+  await page.getByRole('link', { name: 'Mock Article Title' }).click()
+  await expect(page).toHaveURL('/article/mock-gist-id')
+  expect(await page.evaluate(() => (window as Window & { __noReload?: boolean }).__noReload)).toBe(
+    true
+  )
+
+  // The full managed set is re-synced from the destination page — title, description,
+  // canonical, og:url, og:type, and the article's JSON-LD that the list never had.
+  await expect(page).toHaveTitle('Mock Article Title by Masoud Soroush · SOROUSH.TECH')
+  await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+    'content',
+    'Mock Article Title - Masoud Soroush'
+  )
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://soroush.tech/article/mock-gist-id/'
+  )
+  await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+    'content',
+    'https://soroush.tech/article/mock-gist-id/'
+  )
+  await expect(page.locator('meta[property="og:type"]')).toHaveAttribute('content', 'article')
+  await expect(page.locator('script[type="application/ld+json"]')).toHaveCount(1)
+
+  // Navigating back removes the article-only tags — proving stale tags are cleared, not stacked.
+  await page.goBack()
+  await expect(page).toHaveURL('/articles')
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://soroush.tech/articles/'
+  )
+  await expect(page.locator('meta[property="og:type"]')).toHaveAttribute('content', 'website')
+  await expect(page.locator('script[type="application/ld+json"]')).toHaveCount(0)
 })
 
 test('robots.txt is served and points to the sitemap', async ({ request }) => {


### PR DESCRIPTION
Vike client routing only updated document.title on navigation, leaving description, canonical, og:*, twitter:*, robots, and JSON-LD frozen at the first SSR render. Introduce collectHeadTags as the single source of truth for both buildHead (server HTML) and a new applyHead client reconciler that removes the previous page's data-mh-marked tags and re-emits the destination page's set on each navigation. Widen description/robots config env to the client so they resolve during client routing; CSP stays server-only.

Also harden the articles client-routing e2e: wait for hydration and assert no full reload so it genuinely exercises Vike client routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SEO head tag synchronization during client-side navigation, ensuring title, meta description, canonical URLs, OpenGraph tags, robots directives, and JSON-LD update correctly without full document reloads.
* **Tests**
  * Expanded E2E coverage to confirm metadata remains correct after navigation between article pages and the articles list, including proper addition/removal of article-specific JSON-LD.
  * Enhanced unit/integration tests for server-rendered and client-applied managed head tag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->