### PR TITLE
feat(styled-system): export per-property prop types and loosen Transform for drop-in parity

### DIFF
--- a/packages/styled-system/package.json
+++ b/packages/styled-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soroush.tech/styled-system",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Maintained, first-class-TypeScript rewrite of styled-system — responsive, theme-aware style props for CSS-in-JS. Drop-in replacement for styled-system v5.",
   "keywords": [
     "styled-system",

--- a/packages/styled-system/src/background/index.ts
+++ b/packages/styled-system/src/background/index.ts
@@ -1,2 +1,9 @@
 export * from './background'
 export { default } from './background'
+export type {
+  BackgroundImageProps,
+  BackgroundSizeProps,
+  BackgroundPositionProps,
+  BackgroundRepeatProps,
+  BackgroundProps,
+} from '../types'

--- a/packages/styled-system/src/border/index.ts
+++ b/packages/styled-system/src/border/index.ts
@@ -1,2 +1,13 @@
 export * from './border'
 export { default } from './border'
+export type {
+  BorderWidthProps,
+  BorderStyleProps,
+  BorderColorProps,
+  BorderRadiusProps,
+  BorderTopProps,
+  BorderRightProps,
+  BorderBottomProps,
+  BorderLeftProps,
+  BorderProps,
+} from '../types'

--- a/packages/styled-system/src/color/index.ts
+++ b/packages/styled-system/src/color/index.ts
@@ -1,2 +1,3 @@
 export * from './color'
 export { default } from './color'
+export type { TextColorProps, BackgroundColorProps, OpacityProps, ColorProps } from '../types'

--- a/packages/styled-system/src/core/core.ts
+++ b/packages/styled-system/src/core/core.ts
@@ -29,7 +29,9 @@ export interface Props {
   [key: string]: unknown
 }
 
-export type Transform = (value: unknown, scale?: unknown, props?: Props) => unknown
+// Loose by design, matching @styled-system/core's `(value: any, scale?: any) => any`.
+// Keeps consumer transforms like `(val) => MAP[val] ?? MAP.center` valid without casts.
+export type Transform = (value: any, scale?: any, props?: Props) => any
 
 export interface StyleFn {
   (value: unknown, scale?: unknown, props?: Props): StyleObject | undefined

--- a/packages/styled-system/src/flexbox/index.ts
+++ b/packages/styled-system/src/flexbox/index.ts
@@ -1,2 +1,18 @@
 export * from './flexbox'
 export { default } from './flexbox'
+export type {
+  AlignItemsProps,
+  AlignContentProps,
+  JustifyItemsProps,
+  JustifyContentProps,
+  FlexWrapProps,
+  FlexDirectionProps,
+  FlexProps,
+  FlexGrowProps,
+  FlexShrinkProps,
+  FlexBasisProps,
+  JustifySelfProps,
+  AlignSelfProps,
+  OrderProps,
+  FlexboxProps,
+} from '../types'

--- a/packages/styled-system/src/grid/index.ts
+++ b/packages/styled-system/src/grid/index.ts
@@ -1,2 +1,17 @@
 export * from './grid'
 export { default } from './grid'
+export type {
+  GridGapProps,
+  GridColumnGapProps,
+  GridRowGapProps,
+  GridColumnProps,
+  GridRowProps,
+  GridAutoFlowProps,
+  GridAutoColumnsProps,
+  GridAutoRowsProps,
+  GridTemplateColumnsProps,
+  GridTemplateRowsProps,
+  GridTemplateAreasProps,
+  GridAreaProps,
+  GridProps,
+} from '../types'

--- a/packages/styled-system/src/index.test.ts
+++ b/packages/styled-system/src/index.test.ts
@@ -16,6 +16,7 @@ describe('aggregator', () => {
     expect(typeof ss.zIndex).toBe('function')
     expect(typeof ss.style).toBe('function')
     expect(typeof ss.variant).toBe('function')
+    expect(typeof ss.themeGet).toBe('function')
   })
 
   it('aliases borders to border and box/textShadow to shadow', () => {

--- a/packages/styled-system/src/index.ts
+++ b/packages/styled-system/src/index.ts
@@ -40,6 +40,7 @@ export {
   shadow as textShadow,
 } from '@soroush.tech/styled-system/shadow'
 export { variant, buttonStyle, textStyle, colorStyle } from '@soroush.tech/styled-system/variant'
+export { themeGet } from '@soroush.tech/styled-system/theme-get'
 export { style } from './style'
 export * from './types'
 

--- a/packages/styled-system/src/layout/index.ts
+++ b/packages/styled-system/src/layout/index.ts
@@ -1,2 +1,15 @@
 export * from './layout'
 export { default } from './layout'
+export type {
+  WidthProps,
+  HeightProps,
+  MinWidthProps,
+  MinHeightProps,
+  MaxWidthProps,
+  MaxHeightProps,
+  SizeProps,
+  DisplayProps,
+  OverflowProps,
+  VerticalAlignProps,
+  LayoutProps,
+} from '../types'

--- a/packages/styled-system/src/position/index.ts
+++ b/packages/styled-system/src/position/index.ts
@@ -1,2 +1,10 @@
 export * from './position'
 export { default } from './position'
+export type {
+  ZIndexProps,
+  TopProps,
+  RightProps,
+  BottomProps,
+  LeftProps,
+  PositionProps,
+} from '../types'

--- a/packages/styled-system/src/shadow/index.ts
+++ b/packages/styled-system/src/shadow/index.ts
@@ -1,2 +1,3 @@
 export * from './shadow'
 export { default } from './shadow'
+export type { BoxShadowProps, TextShadowProps, ShadowProps } from '../types'

--- a/packages/styled-system/src/space/index.ts
+++ b/packages/styled-system/src/space/index.ts
@@ -1,2 +1,3 @@
 export * from './space'
 export { default } from './space'
+export type { MarginProps, PaddingProps, SpaceProps } from '../types'

--- a/packages/styled-system/src/types.ts
+++ b/packages/styled-system/src/types.ts
@@ -3,6 +3,12 @@
 // generic, theme-scale-aware prop interfaces mirror @types/styled-system@5.1.25 so this
 // package is a drop-in replacement. The one deviation: ThemeValue's inference helper
 // uses `unknown` instead of the original's `any`.
+//
+// Structure mirrors upstream: one atomic interface per CSS property, with each grouped
+// interface composing them via `extends`. Consumers can import either the group
+// (`LayoutProps`) or a single property (`WidthProps`), from the main entry or the
+// matching subpath. Three intentional widenings over upstream are preserved:
+// `boxShadow`/`textShadow` and `fontWeight` additionally accept `string` theme keys.
 import type * as CSS from 'csstype'
 
 export type ObjectOrArray<T, K extends keyof never = keyof never> =
@@ -52,11 +58,9 @@ export type ResponsiveValue<T, ThemeType extends Theme = RequiredTheme> =
   | Array<T | null>
   | { [key in (ThemeValue<'breakpoints', ThemeType> & string) | number]?: T }
 
-export interface SpaceProps<
-  ThemeType extends Theme = RequiredTheme,
-  TVal = ThemeValue<'space', ThemeType>,
->
-  extends MarginProps<ThemeType, TVal>, PaddingProps<ThemeType, TVal> {}
+// ---------------------------------------------------------------------------
+// space
+// ---------------------------------------------------------------------------
 
 export interface MarginProps<
   ThemeType extends Theme = RequiredTheme,
@@ -98,108 +102,552 @@ export interface PaddingProps<
   paddingY?: ResponsiveValue<TVal, ThemeType>
 }
 
-export interface LayoutProps<ThemeType extends Theme = RequiredTheme> {
-  width?: ResponsiveValue<CSS.Property.Width<TLengthStyledSystem>, ThemeType>
-  height?: ResponsiveValue<CSS.Property.Height<TLengthStyledSystem>, ThemeType>
-  minWidth?: ResponsiveValue<CSS.Property.MinWidth<TLengthStyledSystem>, ThemeType>
-  minHeight?: ResponsiveValue<CSS.Property.MinHeight<TLengthStyledSystem>, ThemeType>
-  maxWidth?: ResponsiveValue<CSS.Property.MaxWidth<TLengthStyledSystem>, ThemeType>
-  maxHeight?: ResponsiveValue<CSS.Property.MaxHeight<TLengthStyledSystem>, ThemeType>
-  size?: ResponsiveValue<CSS.Property.Width<TLengthStyledSystem>, ThemeType>
+export interface SpaceProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = ThemeValue<'space', ThemeType>,
+>
+  extends MarginProps<ThemeType, TVal>, PaddingProps<ThemeType, TVal> {}
+
+// ---------------------------------------------------------------------------
+// layout
+// ---------------------------------------------------------------------------
+
+export interface WidthProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.Width<TLengthStyledSystem>,
+> {
+  width?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface HeightProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.Height<TLengthStyledSystem>,
+> {
+  height?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface MinWidthProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.MinWidth<TLengthStyledSystem>,
+> {
+  minWidth?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface MinHeightProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.MinHeight<TLengthStyledSystem>,
+> {
+  minHeight?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface MaxWidthProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.MaxWidth<TLengthStyledSystem>,
+> {
+  maxWidth?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface MaxHeightProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.MaxHeight<TLengthStyledSystem>,
+> {
+  maxHeight?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface SizeProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.Height<TLengthStyledSystem>,
+> {
+  size?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface DisplayProps<ThemeType extends Theme = RequiredTheme> {
+  display?: ResponsiveValue<CSS.Property.Display, ThemeType>
+}
+
+export interface OverflowProps<ThemeType extends Theme = RequiredTheme> {
   overflow?: ResponsiveValue<CSS.Property.Overflow, ThemeType>
   overflowX?: ResponsiveValue<CSS.Property.OverflowX, ThemeType>
   overflowY?: ResponsiveValue<CSS.Property.OverflowY, ThemeType>
-  display?: ResponsiveValue<CSS.Property.Display, ThemeType>
-  verticalAlign?: ResponsiveValue<CSS.Property.VerticalAlign<TLengthStyledSystem>, ThemeType>
 }
 
-export interface TypographyProps<ThemeType extends Theme = RequiredTheme> {
+export interface VerticalAlignProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.VerticalAlign<TLengthStyledSystem>,
+> {
+  verticalAlign?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface LayoutProps<ThemeType extends Theme = RequiredTheme>
+  extends
+    WidthProps<ThemeType>,
+    HeightProps<ThemeType>,
+    MinWidthProps<ThemeType>,
+    MinHeightProps<ThemeType>,
+    MaxWidthProps<ThemeType>,
+    MaxHeightProps<ThemeType>,
+    DisplayProps<ThemeType>,
+    VerticalAlignProps<ThemeType>,
+    SizeProps<ThemeType>,
+    OverflowProps<ThemeType> {}
+
+// ---------------------------------------------------------------------------
+// typography
+// ---------------------------------------------------------------------------
+
+export interface FontFamilyProps<ThemeType extends Theme = RequiredTheme> {
   fontFamily?: ResponsiveValue<CSS.Property.FontFamily, ThemeType>
-  fontSize?: ResponsiveValue<ThemeValue<'fontSizes', ThemeType>, ThemeType>
-  fontWeight?: ResponsiveValue<ThemeValue<'fontWeights', ThemeType> | string, ThemeType>
-  lineHeight?: ResponsiveValue<ThemeValue<'lineHeights', ThemeType>, ThemeType>
-  letterSpacing?: ResponsiveValue<CSS.Property.LetterSpacing<TLengthStyledSystem>, ThemeType>
-  textAlign?: ResponsiveValue<CSS.Property.TextAlign, ThemeType>
+}
+
+export interface FontSizeProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = ThemeValue<'fontSizes', ThemeType>,
+> {
+  fontSize?: ResponsiveValue<TVal, ThemeType>
+}
+
+// Widened over upstream: also accepts `string` theme keys.
+export interface FontWeightProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = ThemeValue<'fontWeights', ThemeType> | string,
+> {
+  fontWeight?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface LineHeightProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = ThemeValue<'lineHeights', ThemeType>,
+> {
+  lineHeight?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface LetterSpacingProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.LetterSpacing<TLengthStyledSystem>,
+> {
+  letterSpacing?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface FontStyleProps<ThemeType extends Theme = RequiredTheme> {
   fontStyle?: ResponsiveValue<CSS.Property.FontStyle, ThemeType>
 }
 
-export interface FlexboxProps<ThemeType extends Theme = RequiredTheme> {
+export interface TextAlignProps<ThemeType extends Theme = RequiredTheme> {
+  textAlign?: ResponsiveValue<CSS.Property.TextAlign, ThemeType>
+}
+
+export interface TypographyProps<ThemeType extends Theme = RequiredTheme>
+  extends
+    FontFamilyProps<ThemeType>,
+    FontSizeProps<ThemeType>,
+    FontWeightProps<ThemeType>,
+    LineHeightProps<ThemeType>,
+    LetterSpacingProps<ThemeType>,
+    FontStyleProps<ThemeType>,
+    TextAlignProps<ThemeType> {}
+
+// ---------------------------------------------------------------------------
+// flexbox
+// ---------------------------------------------------------------------------
+
+export interface AlignItemsProps<ThemeType extends Theme = RequiredTheme> {
   alignItems?: ResponsiveValue<CSS.Property.AlignItems, ThemeType>
+}
+
+export interface AlignContentProps<ThemeType extends Theme = RequiredTheme> {
   alignContent?: ResponsiveValue<CSS.Property.AlignContent, ThemeType>
+}
+
+export interface JustifyItemsProps<ThemeType extends Theme = RequiredTheme> {
   justifyItems?: ResponsiveValue<CSS.Property.JustifyItems, ThemeType>
+}
+
+export interface JustifyContentProps<ThemeType extends Theme = RequiredTheme> {
   justifyContent?: ResponsiveValue<CSS.Property.JustifyContent, ThemeType>
+}
+
+export interface FlexWrapProps<ThemeType extends Theme = RequiredTheme> {
   flexWrap?: ResponsiveValue<CSS.Property.FlexWrap, ThemeType>
+}
+
+export interface FlexDirectionProps<ThemeType extends Theme = RequiredTheme> {
   flexDirection?: ResponsiveValue<CSS.Property.FlexDirection, ThemeType>
-  flex?: ResponsiveValue<CSS.Property.Flex<TLengthStyledSystem>, ThemeType>
+}
+
+export interface FlexProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.Flex<TLengthStyledSystem>,
+> {
+  flex?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface FlexGrowProps<ThemeType extends Theme = RequiredTheme> {
   flexGrow?: ResponsiveValue<CSS.Property.FlexGrow, ThemeType>
+}
+
+export interface FlexShrinkProps<ThemeType extends Theme = RequiredTheme> {
   flexShrink?: ResponsiveValue<CSS.Property.FlexShrink, ThemeType>
-  flexBasis?: ResponsiveValue<CSS.Property.FlexBasis<TLengthStyledSystem>, ThemeType>
+}
+
+export interface FlexBasisProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.FlexBasis<TLengthStyledSystem>,
+> {
+  flexBasis?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface JustifySelfProps<ThemeType extends Theme = RequiredTheme> {
   justifySelf?: ResponsiveValue<CSS.Property.JustifySelf, ThemeType>
+}
+
+export interface AlignSelfProps<ThemeType extends Theme = RequiredTheme> {
   alignSelf?: ResponsiveValue<CSS.Property.AlignSelf, ThemeType>
+}
+
+export interface OrderProps<ThemeType extends Theme = RequiredTheme> {
   order?: ResponsiveValue<CSS.Property.Order, ThemeType>
 }
 
-export interface PositionProps<ThemeType extends Theme = RequiredTheme> {
-  position?: ResponsiveValue<CSS.Property.Position, ThemeType>
+export interface FlexboxProps<ThemeType extends Theme = RequiredTheme>
+  extends
+    AlignItemsProps<ThemeType>,
+    AlignContentProps<ThemeType>,
+    JustifyItemsProps<ThemeType>,
+    JustifyContentProps<ThemeType>,
+    FlexWrapProps<ThemeType>,
+    FlexDirectionProps<ThemeType>,
+    FlexProps<ThemeType>,
+    FlexGrowProps<ThemeType>,
+    FlexShrinkProps<ThemeType>,
+    FlexBasisProps<ThemeType>,
+    JustifySelfProps<ThemeType>,
+    AlignSelfProps<ThemeType>,
+    OrderProps<ThemeType> {}
+
+// ---------------------------------------------------------------------------
+// position
+// ---------------------------------------------------------------------------
+
+export interface ZIndexProps<ThemeType extends Theme = RequiredTheme> {
   zIndex?: ResponsiveValue<CSS.Property.ZIndex, ThemeType>
-  top?: ResponsiveValue<CSS.Property.Top<TLengthStyledSystem>, ThemeType>
-  right?: ResponsiveValue<CSS.Property.Right<TLengthStyledSystem>, ThemeType>
-  bottom?: ResponsiveValue<CSS.Property.Bottom<TLengthStyledSystem>, ThemeType>
-  left?: ResponsiveValue<CSS.Property.Left<TLengthStyledSystem>, ThemeType>
+}
+
+export interface TopProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.Top<TLengthStyledSystem>,
+> {
+  top?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface RightProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.Right<TLengthStyledSystem>,
+> {
+  right?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface BottomProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.Bottom<TLengthStyledSystem>,
+> {
+  bottom?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface LeftProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.Left<TLengthStyledSystem>,
+> {
+  left?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface PositionProps<ThemeType extends Theme = RequiredTheme>
+  extends
+    ZIndexProps<ThemeType>,
+    TopProps<ThemeType>,
+    RightProps<ThemeType>,
+    BottomProps<ThemeType>,
+    LeftProps<ThemeType> {
+  position?: ResponsiveValue<CSS.Property.Position, ThemeType>
+}
+
+// ---------------------------------------------------------------------------
+// color
+// ---------------------------------------------------------------------------
+
+export interface TextColorProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = ThemeValue<'colors', ThemeType>,
+> {
+  color?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface BackgroundColorProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = ThemeValue<'colors', ThemeType>,
+> {
+  bg?: ResponsiveValue<TVal, ThemeType>
+  backgroundColor?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface OpacityProps<ThemeType extends Theme = RequiredTheme> {
+  opacity?: ResponsiveValue<CSS.Property.Opacity, ThemeType>
 }
 
 export interface ColorProps<
   ThemeType extends Theme = RequiredTheme,
   TVal = ThemeValue<'colors', ThemeType>,
+>
+  extends
+    TextColorProps<ThemeType, TVal>,
+    BackgroundColorProps<ThemeType, TVal>,
+    OpacityProps<ThemeType> {}
+
+// ---------------------------------------------------------------------------
+// border
+// ---------------------------------------------------------------------------
+
+export interface BorderWidthProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = ThemeValue<'borderWidths', ThemeType>,
 > {
-  color?: ResponsiveValue<TVal, ThemeType>
-  backgroundColor?: ResponsiveValue<TVal, ThemeType>
-  bg?: ResponsiveValue<TVal, ThemeType>
-  opacity?: ResponsiveValue<CSS.Property.Opacity, ThemeType>
+  borderWidth?: ResponsiveValue<TVal, ThemeType>
+  borderTopWidth?: ResponsiveValue<TVal, ThemeType>
+  borderBottomWidth?: ResponsiveValue<TVal, ThemeType>
+  borderLeftWidth?: ResponsiveValue<TVal, ThemeType>
+  borderRightWidth?: ResponsiveValue<TVal, ThemeType>
 }
 
-export interface BorderProps<ThemeType extends Theme = RequiredTheme> {
-  border?: ResponsiveValue<CSS.Property.Border<TLengthStyledSystem>, ThemeType>
-  borderWidth?: ResponsiveValue<CSS.Property.BorderWidth<TLengthStyledSystem>, ThemeType>
+export interface BorderStyleProps<ThemeType extends Theme = RequiredTheme> {
   borderStyle?: ResponsiveValue<CSS.Property.BorderStyle, ThemeType>
-  borderColor?: ResponsiveValue<ThemeValue<'colors', ThemeType>, ThemeType>
-  borderRadius?: ResponsiveValue<ThemeValue<'radii', ThemeType>, ThemeType>
-  borderTop?: ResponsiveValue<CSS.Property.BorderTop<TLengthStyledSystem>, ThemeType>
-  borderRight?: ResponsiveValue<CSS.Property.BorderRight<TLengthStyledSystem>, ThemeType>
-  borderBottom?: ResponsiveValue<CSS.Property.BorderBottom<TLengthStyledSystem>, ThemeType>
-  borderLeft?: ResponsiveValue<CSS.Property.BorderLeft<TLengthStyledSystem>, ThemeType>
+  borderTopStyle?: ResponsiveValue<CSS.Property.BorderTopStyle, ThemeType>
+  borderBottomStyle?: ResponsiveValue<CSS.Property.BorderBottomStyle, ThemeType>
+  borderLeftStyle?: ResponsiveValue<CSS.Property.BorderLeftStyle, ThemeType>
+  borderRightStyle?: ResponsiveValue<CSS.Property.BorderRightStyle, ThemeType>
 }
 
-export interface BackgroundProps<ThemeType extends Theme = RequiredTheme> {
-  background?: ResponsiveValue<CSS.Property.Background<TLengthStyledSystem>, ThemeType>
+export interface BorderColorProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = ThemeValue<'colors', ThemeType>,
+> {
+  borderColor?: ResponsiveValue<TVal, ThemeType>
+  borderTopColor?: ResponsiveValue<TVal, ThemeType>
+  borderBottomColor?: ResponsiveValue<TVal, ThemeType>
+  borderLeftColor?: ResponsiveValue<TVal, ThemeType>
+  borderRightColor?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface BorderRadiusProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = ThemeValue<'radii', ThemeType>,
+> {
+  borderRadius?: ResponsiveValue<TVal, ThemeType>
+  borderTopLeftRadius?: ResponsiveValue<TVal, ThemeType>
+  borderTopRightRadius?: ResponsiveValue<TVal, ThemeType>
+  borderBottomLeftRadius?: ResponsiveValue<TVal, ThemeType>
+  borderBottomRightRadius?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface BorderTopProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.BorderTop<TLengthStyledSystem>,
+> {
+  borderTop?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface BorderRightProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.BorderRight<TLengthStyledSystem>,
+> {
+  borderRight?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface BorderBottomProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.BorderBottom<TLengthStyledSystem>,
+> {
+  borderBottom?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface BorderLeftProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.BorderLeft<TLengthStyledSystem>,
+> {
+  borderLeft?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface BorderProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.Border<TLengthStyledSystem>,
+>
+  extends
+    BorderWidthProps<ThemeType>,
+    BorderStyleProps<ThemeType>,
+    BorderColorProps<ThemeType>,
+    BorderRadiusProps<ThemeType>,
+    BorderTopProps<ThemeType>,
+    BorderRightProps<ThemeType>,
+    BorderBottomProps<ThemeType>,
+    BorderLeftProps<ThemeType> {
+  border?: ResponsiveValue<TVal, ThemeType>
+  borderX?: ResponsiveValue<TVal, ThemeType>
+  borderY?: ResponsiveValue<TVal, ThemeType>
+}
+
+// ---------------------------------------------------------------------------
+// background
+// ---------------------------------------------------------------------------
+
+export interface BackgroundImageProps<ThemeType extends Theme = RequiredTheme> {
   backgroundImage?: ResponsiveValue<CSS.Property.BackgroundImage, ThemeType>
-  backgroundSize?: ResponsiveValue<CSS.Property.BackgroundSize<TLengthStyledSystem>, ThemeType>
-  backgroundPosition?: ResponsiveValue<
-    CSS.Property.BackgroundPosition<TLengthStyledSystem>,
-    ThemeType
-  >
+}
+
+export interface BackgroundSizeProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.BackgroundSize<TLengthStyledSystem>,
+> {
+  backgroundSize?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface BackgroundPositionProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.BackgroundPosition<TLengthStyledSystem>,
+> {
+  backgroundPosition?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface BackgroundRepeatProps<ThemeType extends Theme = RequiredTheme> {
   backgroundRepeat?: ResponsiveValue<CSS.Property.BackgroundRepeat, ThemeType>
 }
 
-export interface GridProps<ThemeType extends Theme = RequiredTheme> {
-  gridGap?: ResponsiveValue<CSS.Property.GridGap<TLengthStyledSystem>, ThemeType>
-  gridColumnGap?: ResponsiveValue<CSS.Property.GridColumnGap<TLengthStyledSystem>, ThemeType>
-  gridRowGap?: ResponsiveValue<CSS.Property.GridRowGap<TLengthStyledSystem>, ThemeType>
+export interface BackgroundProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.Background<TLengthStyledSystem>,
+>
+  extends
+    BackgroundImageProps<ThemeType>,
+    BackgroundSizeProps<ThemeType>,
+    BackgroundPositionProps<ThemeType>,
+    BackgroundRepeatProps<ThemeType> {
+  background?: ResponsiveValue<TVal, ThemeType>
+}
+
+// ---------------------------------------------------------------------------
+// grid
+// ---------------------------------------------------------------------------
+
+export interface GridGapProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.GridGap<TLengthStyledSystem>,
+> {
+  gridGap?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface GridColumnGapProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.GridColumnGap<TLengthStyledSystem>,
+> {
+  gridColumnGap?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface GridRowGapProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.GridRowGap<TLengthStyledSystem>,
+> {
+  gridRowGap?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface GridColumnProps<ThemeType extends Theme = RequiredTheme> {
   gridColumn?: ResponsiveValue<CSS.Property.GridColumn, ThemeType>
+}
+
+export interface GridRowProps<ThemeType extends Theme = RequiredTheme> {
   gridRow?: ResponsiveValue<CSS.Property.GridRow, ThemeType>
+}
+
+export interface GridAutoFlowProps<ThemeType extends Theme = RequiredTheme> {
   gridAutoFlow?: ResponsiveValue<CSS.Property.GridAutoFlow, ThemeType>
-  gridAutoColumns?: ResponsiveValue<CSS.Property.GridAutoColumns<TLengthStyledSystem>, ThemeType>
-  gridAutoRows?: ResponsiveValue<CSS.Property.GridAutoRows<TLengthStyledSystem>, ThemeType>
-  gridTemplateColumns?: ResponsiveValue<
-    CSS.Property.GridTemplateColumns<TLengthStyledSystem>,
-    ThemeType
-  >
-  gridTemplateRows?: ResponsiveValue<CSS.Property.GridTemplateRows<TLengthStyledSystem>, ThemeType>
+}
+
+export interface GridAutoColumnsProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.GridAutoColumns<TLengthStyledSystem>,
+> {
+  gridAutoColumns?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface GridAutoRowsProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.GridAutoRows<TLengthStyledSystem>,
+> {
+  gridAutoRows?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface GridTemplateColumnsProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.GridTemplateColumns<TLengthStyledSystem>,
+> {
+  gridTemplateColumns?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface GridTemplateRowsProps<
+  ThemeType extends Theme = RequiredTheme,
+  TVal = CSS.Property.GridTemplateRows<TLengthStyledSystem>,
+> {
+  gridTemplateRows?: ResponsiveValue<TVal, ThemeType>
+}
+
+export interface GridTemplateAreasProps<ThemeType extends Theme = RequiredTheme> {
   gridTemplateAreas?: ResponsiveValue<CSS.Property.GridTemplateAreas, ThemeType>
+}
+
+export interface GridAreaProps<ThemeType extends Theme = RequiredTheme> {
   gridArea?: ResponsiveValue<CSS.Property.GridArea, ThemeType>
 }
 
-export interface ShadowProps<ThemeType extends Theme = RequiredTheme> {
+export interface GridProps<ThemeType extends Theme = RequiredTheme>
+  extends
+    GridGapProps<ThemeType>,
+    GridColumnGapProps<ThemeType>,
+    GridRowGapProps<ThemeType>,
+    GridColumnProps<ThemeType>,
+    GridRowProps<ThemeType>,
+    GridAutoFlowProps<ThemeType>,
+    GridAutoColumnsProps<ThemeType>,
+    GridAutoRowsProps<ThemeType>,
+    GridTemplateColumnsProps<ThemeType>,
+    GridTemplateRowsProps<ThemeType>,
+    GridTemplateAreasProps<ThemeType>,
+    GridAreaProps<ThemeType> {}
+
+// ---------------------------------------------------------------------------
+// shadow
+// ---------------------------------------------------------------------------
+
+// Widened over upstream: also accepts `string` theme keys.
+export interface BoxShadowProps<ThemeType extends Theme = RequiredTheme> {
   boxShadow?: ResponsiveValue<CSS.Property.BoxShadow | string, ThemeType>
+}
+
+// Widened over upstream: also accepts `string` theme keys.
+export interface TextShadowProps<ThemeType extends Theme = RequiredTheme> {
   textShadow?: ResponsiveValue<CSS.Property.TextShadow | string, ThemeType>
+}
+
+export interface ShadowProps<ThemeType extends Theme = RequiredTheme>
+  extends BoxShadowProps<ThemeType>, TextShadowProps<ThemeType> {}
+
+// ---------------------------------------------------------------------------
+// variant
+// ---------------------------------------------------------------------------
+
+export interface TextStyleProps<ThemeType extends Theme = RequiredTheme> {
+  textStyle?: ResponsiveValue<string, ThemeType>
+}
+
+export interface ButtonStyleProps<ThemeType extends Theme = RequiredTheme> {
+  variant?: ResponsiveValue<string, ThemeType>
+}
+
+export interface ColorStyleProps<ThemeType extends Theme = RequiredTheme> {
+  colors?: ResponsiveValue<string, ThemeType>
 }

--- a/packages/styled-system/src/typography/index.ts
+++ b/packages/styled-system/src/typography/index.ts
@@ -1,2 +1,12 @@
 export * from './typography'
 export { default } from './typography'
+export type {
+  FontFamilyProps,
+  FontSizeProps,
+  FontWeightProps,
+  LineHeightProps,
+  LetterSpacingProps,
+  FontStyleProps,
+  TextAlignProps,
+  TypographyProps,
+} from '../types'

--- a/packages/styled-system/src/variant/index.ts
+++ b/packages/styled-system/src/variant/index.ts
@@ -1,2 +1,3 @@
 export * from './variant'
 export { default } from './variant'
+export type { TextStyleProps, ButtonStyleProps, ColorStyleProps } from '../types'


### PR DESCRIPTION
## Context

`@soroush.tech/styled-system@5.2.0` was trialled as a straight replacement for `styled-system@5` + `@types/styled-system` in a large consumer repo. Runtime matched, but two things forced local workarounds, so it was not yet a true drop-in. This PR closes those gaps.

Closes #213

## Changes

### 1. Fine-grained per-property prop types (main blocker)
`@types/styled-system` exports one interface **per property**; consumers import those to type exactly the props a component styles. We only exported the 12 grouped interfaces, so ~28 had to be recreated locally via `Pick`.

- Added the atomic per-property interfaces to `src/types.ts` (`WidthProps`, `HeightProps`, `OverflowProps`, `TopProps`, `ZIndexProps`, `AlignItemsProps`, `JustifyContentProps`, `FlexProps`, `FontSizeProps`, `FontWeightProps`, `LineHeightProps`, `TextAlignProps`, `TextColorProps`, `BackgroundColorProps`, `OpacityProps`, `BorderWidthProps`, `BorderStyleProps`, `BorderColorProps`, `BorderRadiusProps`, `BorderTop/Right/Bottom/LeftProps`, `BoxShadowProps`, `TextShadowProps`, `TextStyleProps`, and the full `Grid*` and `Background*` families).
- Recomposed each grouped interface (`LayoutProps`, `FlexboxProps`, `BorderProps`, …) to `extends` its atomics — mirroring upstream's structure, single source of truth, no drift.
- Re-exported every type from its matching subpath (`./layout`, `./position`, `./border`, …) as the runtime functions already are.

### 2. `Transform` no longer types the value as `unknown`
`Transform` now matches `@styled-system/core`'s `(value: any, scale?: any) => any` (keeping the extra `props` param), so consumer transforms like `(val) => MAP[val] ?? MAP.center` compile without casts (no more TS2538).

### 3. `themeGet` from the main entry
Added `export { themeGet }` so `import { themeGet } from '@soroush.tech/styled-system'` works alongside the subpath default/named forms.

## Notes

- `boxShadow`, `textShadow`, and `fontWeight` keep their intentional widening over upstream (also accept `string` theme keys) — a harmless superset that preserves current app behavior.
- No runtime behavior changes; fully backward compatible.
- Package bumped **5.2.0 → 5.3.0** (additive type exports = minor).
- Deferred to a follow-up: a `@styled-system/prop-types` equivalent (issue #213 §3).

## Verification

- `pnpm typecheck` (package) ✅
- `pnpm lint` (`--max-warnings 0`) ✅
- `pnpm test` 59/59 ✅ · `pnpm test:coverage` **100%** ✅
- `pnpm build` — per-subpath `.d.ts` now include the atomic types ✅
- `apps/web` `tsc -b` ✅ — backward compatible; widened border group + extra atomics are additive (verified against `Omit<BorderProps<Theme>, …>` in `src/theme/View/View.tsx`)
- Parity spot-check: atomic types import from both the main entry and a subpath; `themeGet` named import resolves; the map-indexing transform compiles with no TS2538.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the styled-system API with more granular type exports for layout, typography, flexbox, color, border, background, grid, shadow, space, position, and variants.
  * Added a top-level `themeGet` export for easier access.

* **Chores**
  * Bumped the styled-system package version to `5.3.0`.

* **Tests**
  * Updated coverage to verify the new `themeGet` export is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->