### PR TITLE
feat(styled-system): add prop-types subpath and root themeGet default

### DIFF
--- a/packages/styled-system/README.md
+++ b/packages/styled-system/README.md
@@ -38,10 +38,10 @@ pnpm add @soroush.tech/styled-system
 yarn add @soroush.tech/styled-system
 ```
 
-`@emotion/is-prop-valid` (`^1.4.0`) is a peer dependency used only by the
-[`should-forward-prop`](#subpath-imports) entry — install it if you import that subpath.
-You bring your own CSS-in-JS library (Emotion, styled-components, …); the core carries
-neither at runtime.
+`@emotion/is-prop-valid` (`^1.4.0`, peer) and `prop-types` (`^15.8.1`, optional peer) are
+each used by a single [subpath](#subpath-imports) — `should-forward-prop` and `prop-types`
+respectively. Install one only if you import that subpath. You bring your own CSS-in-JS
+library (Emotion, styled-components, …); the core carries neither at runtime.
 
 ## Usage
 
@@ -110,11 +110,15 @@ Subpaths mirror the original `@styled-system/*` packages:
 import { css } from '@soroush.tech/styled-system/css'
 import { themeGet } from '@soroush.tech/styled-system/theme-get'
 import { pick, omit } from '@soroush.tech/styled-system/props'
+import propTypes, { createPropTypes } from '@soroush.tech/styled-system/prop-types'
 import shouldForwardProp, {
   createShouldForwardProp,
   props,
 } from '@soroush.tech/styled-system/should-forward-prop'
 ```
+
+`themeGet` is also re-exported from the package root (as both a named and the default
+export), so `import { themeGet } from '@soroush.tech/styled-system'` works too.
 
 ## Drop-in via alias
 
@@ -126,8 +130,9 @@ Existing `styled-system` users can swap with a package-manager alias — no code
 }
 ```
 
-`@styled-system/should-forward-prop` maps to the
-`@soroush.tech/styled-system/should-forward-prop` subpath.
+Every `@styled-system/*` satellite maps 1:1 to the matching
+`@soroush.tech/styled-system/*` subpath — e.g. `@styled-system/should-forward-prop`,
+`@styled-system/prop-types`, `@styled-system/theme-get`, `@styled-system/css`.
 
 ## Documentation
 

--- a/packages/styled-system/package.json
+++ b/packages/styled-system/package.json
@@ -44,6 +44,7 @@
     "./css": "./src/css/index.ts",
     "./theme-get": "./src/theme-get/index.ts",
     "./props": "./src/props/index.ts",
+    "./prop-types": "./src/prop-types/index.ts",
     "./should-forward-prop": "./src/should-forward-prop/index.ts"
   },
   "imports": {
@@ -213,6 +214,16 @@
           "default": "./dist/props.cjs"
         }
       },
+      "./prop-types": {
+        "import": {
+          "types": "./dist/prop-types.d.mts",
+          "default": "./dist/prop-types.mjs"
+        },
+        "require": {
+          "types": "./dist/prop-types.d.cts",
+          "default": "./dist/prop-types.cjs"
+        }
+      },
       "./should-forward-prop": {
         "import": {
           "types": "./dist/should-forward-prop.d.mts",
@@ -240,14 +251,22 @@
     "csstype": "^3.1.3"
   },
   "peerDependencies": {
-    "@emotion/is-prop-valid": "^1.4.0"
+    "@emotion/is-prop-valid": "^1.4.0",
+    "prop-types": "^15.8.1"
+  },
+  "peerDependenciesMeta": {
+    "prop-types": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@emotion/is-prop-valid": "^1.4.0",
     "@soroush.tech/eslint-config": "workspace:*",
+    "@types/prop-types": "^15.7.12",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.5.0",
     "globals": "^17.7.0",
+    "prop-types": "^15.8.1",
     "tsdown": "^0.22.3",
     "typescript": "~6.0.3",
     "vitest": "^4.1.9"

--- a/packages/styled-system/src/index.test.ts
+++ b/packages/styled-system/src/index.test.ts
@@ -17,6 +17,7 @@ describe('aggregator', () => {
     expect(typeof ss.style).toBe('function')
     expect(typeof ss.variant).toBe('function')
     expect(typeof ss.themeGet).toBe('function')
+    expect(ss.default).toBe(ss.themeGet)
   })
 
   it('aliases borders to border and box/textShadow to shadow', () => {

--- a/packages/styled-system/src/index.ts
+++ b/packages/styled-system/src/index.ts
@@ -40,7 +40,7 @@ export {
   shadow as textShadow,
 } from '@soroush.tech/styled-system/shadow'
 export { variant, buttonStyle, textStyle, colorStyle } from '@soroush.tech/styled-system/variant'
-export { themeGet } from '@soroush.tech/styled-system/theme-get'
+export { themeGet, default } from '@soroush.tech/styled-system/theme-get'
 export { style } from './style'
 export * from './types'
 

--- a/packages/styled-system/src/prop-types/index.ts
+++ b/packages/styled-system/src/prop-types/index.ts
@@ -1,0 +1,2 @@
+export * from './prop-types'
+export { default } from './prop-types'

--- a/packages/styled-system/src/prop-types/prop-types.test.ts
+++ b/packages/styled-system/src/prop-types/prop-types.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import propTypes, { createPropTypes, propType } from './prop-types'
+
+describe('propType', () => {
+  it('is a prop-types validator function', () => {
+    expect(typeof propType).toBe('function')
+  })
+})
+
+describe('createPropTypes', () => {
+  it('maps each prop name to the shared validator', () => {
+    expect(createPropTypes(['margin', 'padding'])).toEqual({
+      margin: propType,
+      padding: propType,
+    })
+  })
+
+  it('returns an empty map for no props', () => {
+    expect(createPropTypes([])).toEqual({})
+  })
+})
+
+describe('default propTypes map', () => {
+  it('exposes a map per style group', () => {
+    expect(Object.keys(propTypes)).toEqual([
+      'space',
+      'color',
+      'layout',
+      'typography',
+      'flexbox',
+      'border',
+      'background',
+      'position',
+      'grid',
+      'shadow',
+      'buttonStyle',
+      'textStyle',
+      'colorStyle',
+    ])
+  })
+
+  it('derives each map from its parser propNames', () => {
+    expect(propTypes.space.margin).toBe(propType)
+    expect(propTypes.color.color).toBe(propType)
+    expect(propTypes.buttonStyle.variant).toBe(propType)
+    expect(propTypes.textStyle.textStyle).toBe(propType)
+    expect(propTypes.colorStyle.colors).toBe(propType)
+  })
+})

--- a/packages/styled-system/src/prop-types/prop-types.ts
+++ b/packages/styled-system/src/prop-types/prop-types.ts
@@ -1,0 +1,60 @@
+// Typed rewrite of @styled-system/prop-types (styled-system v5).
+// Builds React `propTypes` maps from each parser's `propNames`, so a component can
+// spread the props a styled-system function accepts:
+//   Box.propTypes = { ...propTypes.space, ...propTypes.color }
+import PropTypes from 'prop-types'
+import { background } from '@soroush.tech/styled-system/background'
+import { border } from '@soroush.tech/styled-system/border'
+import { color } from '@soroush.tech/styled-system/color'
+import { flexbox } from '@soroush.tech/styled-system/flexbox'
+import { grid } from '@soroush.tech/styled-system/grid'
+import { layout } from '@soroush.tech/styled-system/layout'
+import { position } from '@soroush.tech/styled-system/position'
+import { shadow } from '@soroush.tech/styled-system/shadow'
+import { space } from '@soroush.tech/styled-system/space'
+import { typography } from '@soroush.tech/styled-system/typography'
+import { buttonStyle, colorStyle, textStyle } from '@soroush.tech/styled-system/variant'
+
+// A React prop-types validator. Declared structurally so our public `.d.ts` does not
+// leak `@types/prop-types` onto consumers.
+export type PropTypeValidator = (
+  props: Record<string, unknown>,
+  propName: string,
+  componentName: string,
+  location: string,
+  propFullName: string
+) => Error | null
+
+export type PropTypeMap = Record<string, PropTypeValidator>
+
+// Every style prop is a number, string, responsive array, or responsive object.
+export const propType = PropTypes.oneOfType([
+  PropTypes.number,
+  PropTypes.string,
+  PropTypes.array,
+  PropTypes.object,
+]) as unknown as PropTypeValidator
+
+export const createPropTypes = (props: string[]): PropTypeMap =>
+  props.reduce<PropTypeMap>((acc, name) => {
+    acc[name] = propType
+    return acc
+  }, {})
+
+const propTypes = {
+  space: createPropTypes(space.propNames),
+  color: createPropTypes(color.propNames),
+  layout: createPropTypes(layout.propNames),
+  typography: createPropTypes(typography.propNames),
+  flexbox: createPropTypes(flexbox.propNames),
+  border: createPropTypes(border.propNames),
+  background: createPropTypes(background.propNames),
+  position: createPropTypes(position.propNames),
+  grid: createPropTypes(grid.propNames),
+  shadow: createPropTypes(shadow.propNames),
+  buttonStyle: createPropTypes(buttonStyle.propNames),
+  textStyle: createPropTypes(textStyle.propNames),
+  colorStyle: createPropTypes(colorStyle.propNames),
+}
+
+export default propTypes

--- a/packages/styled-system/tsdown.config.ts
+++ b/packages/styled-system/tsdown.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     css: 'src/css/index.ts',
     'theme-get': 'src/theme-get/index.ts',
     props: 'src/props/index.ts',
+    'prop-types': 'src/prop-types/index.ts',
     'should-forward-prop': 'src/should-forward-prop/index.ts',
   },
   format: ['esm', 'cjs'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,18 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1))
 
+  labs/bench:
+    dependencies:
+      '@soroush.tech/bench':
+        specifier: workspace:*
+        version: link:../../packages/bench
+      '@soroush.tech/styled-system':
+        specifier: 5.2.0
+        version: 5.2.0(@emotion/is-prop-valid@1.4.0)
+      styled-system:
+        specifier: 5.1.5
+        version: 5.1.5
+
   packages/bench:
     devDependencies:
       '@soroush.tech/eslint-config':
@@ -387,6 +399,9 @@ importers:
       '@soroush.tech/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@types/prop-types':
+        specifier: ^15.7.12
+        version: 15.7.15
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
@@ -396,6 +411,9 @@ importers:
       globals:
         specifier: ^17.7.0
         version: 17.7.0
+      prop-types:
+        specifier: ^15.8.1
+        version: 15.8.1
       tsdown:
         specifier: ^0.22.3
         version: 0.22.3(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@6.0.3)
@@ -3458,6 +3476,14 @@ packages:
         integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==,
       }
 
+  '@soroush.tech/styled-system@5.2.0':
+    resolution:
+      {
+        integrity: sha512-NlUhl1B8/cj19xtP1JWYBFluq4EW+gotr0jBt2679jzrsRzCOUYQr7hHUvDCw4exZUE/C63oIKEFPXHkSqBKfw==,
+      }
+    peerDependencies:
+      '@emotion/is-prop-valid': ^1.4.0
+
   '@speed-highlight/core@1.2.17':
     resolution:
       {
@@ -3619,6 +3645,84 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  '@styled-system/background@5.1.2':
+    resolution:
+      {
+        integrity: sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==,
+      }
+
+  '@styled-system/border@5.1.5':
+    resolution:
+      {
+        integrity: sha512-JvddhNrnhGigtzWRCVuAHepniyVi6hBlimxWDVAdcTuk7aRn9BYJUwfHslURtwYFsF5FoEs8Zmr1oZq2M1AP0A==,
+      }
+
+  '@styled-system/color@5.1.2':
+    resolution:
+      {
+        integrity: sha512-1kCkeKDZkt4GYkuFNKc7vJQMcOmTl3bJY3YBUs7fCNM6mMYJeT1pViQ2LwBSBJytj3AB0o4IdLBoepgSgGl5MA==,
+      }
+
+  '@styled-system/core@5.1.2':
+    resolution:
+      {
+        integrity: sha512-XclBDdNIy7OPOsN4HBsawG2eiWfCcuFt6gxKn1x4QfMIgeO6TOlA2pZZ5GWZtIhCUqEPTgIBta6JXsGyCkLBYw==,
+      }
+
+  '@styled-system/css@5.1.5':
+    resolution:
+      {
+        integrity: sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A==,
+      }
+
+  '@styled-system/flexbox@5.1.2':
+    resolution:
+      {
+        integrity: sha512-6hHV52+eUk654Y1J2v77B8iLeBNtc+SA3R4necsu2VVinSD7+XY5PCCEzBFaWs42dtOEDIa2lMrgL0YBC01mDQ==,
+      }
+
+  '@styled-system/grid@5.1.2':
+    resolution:
+      {
+        integrity: sha512-K3YiV1KyHHzgdNuNlaw8oW2ktMuGga99o1e/NAfTEi5Zsa7JXxzwEnVSDSBdJC+z6R8WYTCYRQC6bkVFcvdTeg==,
+      }
+
+  '@styled-system/layout@5.1.2':
+    resolution:
+      {
+        integrity: sha512-wUhkMBqSeacPFhoE9S6UF3fsMEKFv91gF4AdDWp0Aym1yeMPpqz9l9qS/6vjSsDPF7zOb5cOKC3tcKKOMuDCPw==,
+      }
+
+  '@styled-system/position@5.1.2':
+    resolution:
+      {
+        integrity: sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==,
+      }
+
+  '@styled-system/shadow@5.1.2':
+    resolution:
+      {
+        integrity: sha512-wqniqYb7XuZM7K7C0d1Euxc4eGtqEe/lvM0WjuAFsQVImiq6KGT7s7is+0bNI8O4Dwg27jyu4Lfqo/oIQXNzAg==,
+      }
+
+  '@styled-system/space@5.1.2':
+    resolution:
+      {
+        integrity: sha512-+zzYpR8uvfhcAbaPXhH8QgDAV//flxqxSjHiS9cDFQQUSznXMQmxJegbhcdEF7/eNnJgHeIXv1jmny78kipgBA==,
+      }
+
+  '@styled-system/typography@5.1.2':
+    resolution:
+      {
+        integrity: sha512-BxbVUnN8N7hJ4aaPOd7wEsudeT7CxarR+2hns8XCX1zp0DFfbWw4xYa/olA0oQaqx7F1hzDg+eRaGzAJbF+jOg==,
+      }
+
+  '@styled-system/variant@5.1.5':
+    resolution:
+      {
+        integrity: sha512-Yn8hXAFoWIro8+Q5J8YJd/mP85Teiut3fsGVR9CAxwgNfIAiqlYxsk5iHU7VHJks/0KjL4ATSjmbtCDC/4l1qw==,
+      }
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution:
@@ -4215,6 +4319,12 @@ packages:
     resolution:
       {
         integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==,
+      }
+
+  '@types/prop-types@15.7.15':
+    resolution:
+      {
+        integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==,
       }
 
   '@types/react-dom@19.2.3':
@@ -11147,6 +11257,12 @@ packages:
         integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==,
       }
 
+  styled-system@5.1.5:
+    resolution:
+      {
+        integrity: sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==,
+      }
+
   stylis@4.2.0:
     resolution:
       {
@@ -13899,6 +14015,11 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@soroush.tech/styled-system@5.2.0(@emotion/is-prop-valid@1.4.0)':
+    dependencies:
+      '@emotion/is-prop-valid': 1.4.0
+      csstype: 3.2.3
+
   '@speed-highlight/core@1.2.17': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -14027,6 +14148,57 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@styled-system/background@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/border@5.1.5':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/color@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/core@5.1.2':
+    dependencies:
+      object-assign: 4.1.1
+
+  '@styled-system/css@5.1.5': {}
+
+  '@styled-system/flexbox@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/grid@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/layout@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/position@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/shadow@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/space@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/typography@5.1.2':
+    dependencies:
+      '@styled-system/core': 5.1.2
+
+  '@styled-system/variant@5.1.5':
+    dependencies:
+      '@styled-system/core': 5.1.2
+      '@styled-system/css': 5.1.5
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
@@ -14394,6 +14566,8 @@ snapshots:
   '@types/parse-json@4.0.2': {}
 
   '@types/picomatch@4.0.3': {}
+
+  '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -19554,6 +19728,22 @@ snapshots:
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
+
+  styled-system@5.1.5:
+    dependencies:
+      '@styled-system/background': 5.1.2
+      '@styled-system/border': 5.1.5
+      '@styled-system/color': 5.1.2
+      '@styled-system/core': 5.1.2
+      '@styled-system/flexbox': 5.1.2
+      '@styled-system/grid': 5.1.2
+      '@styled-system/layout': 5.1.2
+      '@styled-system/position': 5.1.2
+      '@styled-system/shadow': 5.1.2
+      '@styled-system/space': 5.1.2
+      '@styled-system/typography': 5.1.2
+      '@styled-system/variant': 5.1.5
+      object-assign: 4.1.1
 
   stylis@4.2.0: {}
 


### PR DESCRIPTION
## Context

Follow-up to #214, closing the last two drop-in-parity gaps with the `styled-system@5` ecosystem. After a head-to-head of all 16 original packages against ours, everything matched **except** `@styled-system/prop-types`, plus a `themeGet` default-export gap that broke root aliasing.

Closes #216 · completes #213 §3.

## Changes

### 1. `./prop-types` subpath (parity with `@styled-system/prop-types`)
- `propType` — `PropTypes.oneOfType([number, string, array, object])`
- `createPropTypes(props)` — maps each name to `propType`
- default export — per-group map (`space, color, layout, typography, flexbox, border, background, position, grid, shadow, buttonStyle, textStyle, colorStyle`), each built from that parser's `propNames`
- `prop-types` is an **optional peer dependency** (`^15.8.1`) and stays **external** in the build (ESM output ~1.6 KB). The public `.d.ts` uses a structural `PropTypeValidator` type, so consumers are **not** forced to install `@types/prop-types`.
- Wired into `package.json` `exports` + `publishConfig.exports` and `tsdown.config.ts`.

### 2. Root `themeGet` default export
A package-manager alias can only bind `@styled-system/theme-get` → the package **root**, not the `/theme-get` subpath. The root exported `themeGet` as a named export only, so `import themeGet from '@styled-system/theme-get'` (default) resolved to `undefined` and crashed at runtime. Now re-exported as **both** named and default.

### 3. Docs
README documents the `prop-types` subpath, its optional peer dep, the root `themeGet` default, and the 1:1 `@styled-system/*` → subpath mapping.

## Notes
- New optional peer dependency: `prop-types` (only needed if you import `./prop-types`).
- Part of the unreleased **5.3.0**; no runtime behavior change to existing exports.
- Brings the head-to-head to **16/16** satellite packages at exact parity.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` (`--max-warnings 0`) ✅ · `pnpm test:coverage` **100%** (64 tests) ✅ · `pnpm build` ✅
- `prop-types` external in output; `.d.ts` free of `@types/prop-types` ✅
- Runtime parity vs built `dist`: named + default, 13-key map, `space.margin === propType`, `buttonStyle.variant === propType` ✅
- `apps/web` `tsc -b` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `prop-types` subpath for styled-system consumers.
  * Expanded package exports so the main entry also re-exports the default theme helper.

* **Documentation**
  * Clarified which peer dependencies are needed for each imported subpath.
  * Updated import examples and alias guidance for the new subpath layout.

* **Tests**
  * Added coverage for the new `prop-types` API and default export behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->