### PR TITLE
fix(styled-system): resolve subpath types under classic node moduleResolution

### DIFF
--- a/packages/styled-system/README.md
+++ b/packages/styled-system/README.md
@@ -117,9 +117,6 @@ import shouldForwardProp, {
 } from '@soroush.tech/styled-system/should-forward-prop'
 ```
 
-`themeGet` is also re-exported from the package root (as both a named and the default
-export), so `import { themeGet } from '@soroush.tech/styled-system'` works too.
-
 ## Drop-in via alias
 
 Existing `styled-system` users can swap with a package-manager alias — no code changes:
@@ -130,9 +127,19 @@ Existing `styled-system` users can swap with a package-manager alias — no code
 }
 ```
 
-Every `@styled-system/*` satellite maps 1:1 to the matching
-`@soroush.tech/styled-system/*` subpath — e.g. `@styled-system/should-forward-prop`,
-`@styled-system/prop-types`, `@styled-system/theme-get`, `@styled-system/css`.
+The satellite `@styled-system/*` packages don't need separate aliases — import them as
+subpaths off the aliased `styled-system` name, and they resolve through this package's
+`exports`:
+
+```ts
+import themeGet from 'styled-system/theme-get'
+import propTypes from 'styled-system/prop-types'
+import { css } from 'styled-system/css'
+import shouldForwardProp from 'styled-system/should-forward-prop'
+```
+
+Types resolve under both modern module resolution (`node16`/`nodenext`/`bundler`, via
+`exports`) and classic `node` (via `typesVersions`).
 
 ## Documentation
 

--- a/packages/styled-system/package.json
+++ b/packages/styled-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soroush.tech/styled-system",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "Maintained, first-class-TypeScript rewrite of styled-system — responsive, theme-aware style props for CSS-in-JS. Drop-in replacement for styled-system v5.",
   "keywords": [
     "styled-system",
@@ -237,7 +237,62 @@
     },
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
-    "types": "./dist/index.d.mts"
+    "types": "./dist/index.d.mts",
+    "typesVersions": {
+      "*": {
+        "core": [
+          "./dist/core.d.cts"
+        ],
+        "space": [
+          "./dist/space.d.cts"
+        ],
+        "color": [
+          "./dist/color.d.cts"
+        ],
+        "layout": [
+          "./dist/layout.d.cts"
+        ],
+        "typography": [
+          "./dist/typography.d.cts"
+        ],
+        "flexbox": [
+          "./dist/flexbox.d.cts"
+        ],
+        "grid": [
+          "./dist/grid.d.cts"
+        ],
+        "background": [
+          "./dist/background.d.cts"
+        ],
+        "border": [
+          "./dist/border.d.cts"
+        ],
+        "position": [
+          "./dist/position.d.cts"
+        ],
+        "shadow": [
+          "./dist/shadow.d.cts"
+        ],
+        "variant": [
+          "./dist/variant.d.cts"
+        ],
+        "css": [
+          "./dist/css.d.cts"
+        ],
+        "theme-get": [
+          "./dist/theme-get.d.cts"
+        ],
+        "props": [
+          "./dist/props.d.cts"
+        ],
+        "prop-types": [
+          "./dist/prop-types.d.cts"
+        ],
+        "should-forward-prop": [
+          "./dist/should-forward-prop.d.cts"
+        ]
+      }
+    }
   },
   "scripts": {
     "build": "tsdown",

--- a/packages/styled-system/src/index.test.ts
+++ b/packages/styled-system/src/index.test.ts
@@ -16,8 +16,6 @@ describe('aggregator', () => {
     expect(typeof ss.zIndex).toBe('function')
     expect(typeof ss.style).toBe('function')
     expect(typeof ss.variant).toBe('function')
-    expect(typeof ss.themeGet).toBe('function')
-    expect(ss.default).toBe(ss.themeGet)
   })
 
   it('aliases borders to border and box/textShadow to shadow', () => {

--- a/packages/styled-system/src/index.ts
+++ b/packages/styled-system/src/index.ts
@@ -40,7 +40,6 @@ export {
   shadow as textShadow,
 } from '@soroush.tech/styled-system/shadow'
 export { variant, buttonStyle, textStyle, colorStyle } from '@soroush.tech/styled-system/variant'
-export { themeGet, default } from '@soroush.tech/styled-system/theme-get'
 export { style } from './style'
 export * from './types'
 


### PR DESCRIPTION
## Context

Consumers on TypeScript's classic `moduleResolution: "node"` (node10 — e.g. a Heft rig) can't resolve the **types** for our subpath entries, even though runtime works fine. Classic `node` resolution doesn't read a package's `exports` map, and our subpaths are exposed only through `exports`, so `tsc` throws `TS2307: Cannot find module 'styled-system/theme-get'` across `theme-get`, `prop-types`, `core`, `css`, `should-forward-prop`, … (Node, Babel, and Jest all read `exports`, so only `tsc` type-resolution is affected.)

Closes #218.

## Changes

### 1. `typesVersions` for node10 type resolution
Added `typesVersions` to **`publishConfig`** (so it only ships in the published `package.json`; the monorepo keeps `exports → ./src`). It maps every subpath in `exports` to its emitted `./dist/<name>.d.cts` — the one type-resolution mechanism classic `node` honors — requiring **nothing** from consumers (no `paths`, no `declare module`, no `moduleResolution` change).

### 2. Root `themeGet`/`default` removed (parity fix)
The original `styled-system` main package has **no `default` export and no `themeGet`** — both only ever lived in the standalone `@styled-system/theme-get`. Our root had picked up `themeGet` + a `default`; removed for exact parity. `themeGet` remains available from the `./theme-get` subpath (named + default).

### 3. README alias guidance
The drop-in path is to alias the **main** `styled-system` name and import satellites as **subpaths off it**, which resolve through our `exports`:
```ts
import themeGet from 'styled-system/theme-get'
import propTypes from 'styled-system/prop-types'
```
(Types resolve under modern resolution via `exports` and under classic `node` via `typesVersions`.)

### 4. Version → 5.5.0

## Verification

- **A/B against the packed tarball** under `moduleResolution: "node"`:
  - **with** `typesVersions` → `tsc --noEmit` exit **0** (`theme-get`, `prop-types`, `core` all resolve)
  - **without** (control) → the exact reported **TS2307**s
- Tarball inspection: published `package.json` carries dist `exports` + `typesVersions` (17 subpaths → `.d.cts`).
- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm test:coverage` **100%** ✅ · `pnpm build` ✅ · `apps/web` `tsc -b` ✅.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage guidance for aliased installs and TypeScript path resolution.
* **Bug Fixes**
  * Improved subpath type lookup for styled-system imports.
  * Removed a top-level `themeGet` export to better match the package’s current public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->