### PR TITLE
chore(CI/CD): remove debug storybook cd-web.yml

### DIFF
--- a/.github/workflows/cd-web.yml
+++ b/.github/workflows/cd-web.yml
@@ -180,23 +180,6 @@ jobs:
           VITE_TURNSTILE_SITEKEY: ${{ secrets.VITE_TURNSTILE_SITEKEY }}
           APP_ENV: production
 
-      # TEMPORARY diagnostic for the silent wrangler-action failure: run the same
-      # commands the action runs, as a raw step where nothing can swallow the output.
-      # Remove once the Pages deploy failure is understood and fixed.
-      - name: Debug wrangler environment
-        working-directory: apps/web
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          set -x
-          node -v
-          npx --version
-          npx --no-install wrangler --version || echo "version exit: $?"
-          npx --no-install wrangler whoami || echo "whoami exit: $?"
-          npx --no-install wrangler pages project list || echo "project list exit: $?"
-          npx --no-install wrangler pages deploy --branch=main || echo "deploy exit: $?"
-
       - name: Deploy Storybook to Cloudflare Pages
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the Storybook deployment workflow by removing temporary diagnostic steps.
  * Storybook deployments now proceed directly after the build completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->