### PR TITLE
fix(CI): grant id-token: write to the bench job for branded relay comments

### DIFF
--- a/.github/workflows/ci.md
+++ b/.github/workflows/ci.md
@@ -173,12 +173,13 @@ if: >-
 | 6   | Mint bot token                                            | `actions/create-github-app-token@v2`; skipped unless `vars.BENCH_BOT_APP_ID` is set                  |
 | 7   | Run benchmark gate                                        | `uses: soroush-tech/bench-action@v1` with `baseline-case: previous`, `min-ratio: '80'` and the token |
 
-The results comment is posted with the org GitHub App's token (step 6, from
-`vars.BENCH_BOT_APP_ID` + `secrets.BENCH_BOT_PRIVATE_KEY`) so it appears under
-the brand bot identity; without the app config the gate falls back to
-`GITHUB_TOKEN` (`pull-requests: write`, comment author `github-actions[bot]`).
-On a read-only token the comment is skipped with a warning and only the gate
-decides the job.
+Since bench-action 1.1.0 the results comment is posted **via the OIDC-verified relay**
+(`api.bench.soroush.tech`) as the bench bot — that's what the job's `id-token: write`
+permission is for. On any relay failure the action falls back to direct token
+commenting: first the org GitHub App's token (step 6, from `vars.BENCH_BOT_APP_ID` +
+`secrets.BENCH_BOT_PRIVATE_KEY`), else `GITHUB_TOKEN` (`pull-requests: write`, comment
+author `github-actions[bot]`). On a read-only token the comment is skipped with a
+warning and only the gate decides the job.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # bench-action posts/updates the results comment
+      id-token: write # OIDC token for the branded comment relay (api.bench.soroush.tech)
     environment: CI
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## What

bench-action 1.1.0 posts the benchmark results comment through the OIDC-verified relay at `api.bench.soroush.tech` (see #308 / #310), but the `bench` job never granted `id-token: write` — so the token mint failed and every run silently fell back to direct token commenting.

- `ci.yml`: add `id-token: write` to the bench job's permissions.
- `ci.md`: document the relay-first comment flow and its two-stage fallback (org App token → `GITHUB_TOKEN`).

## Verification

This PR is its own end-to-end test: editing `ci.yml` is an infra change, which puts every package in the CI matrix and triggers the bench job — and since `pull_request` runs use the head's workflow file, the new permission applies to this very run. Expected outcome: the results comment on this PR is authored by the bench bot and the job log shows "Posted the branded PR comment via the relay."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark workflow documentation to clarify how results are posted to pull requests, including relay verification, fallback behavior, and read-only token handling.
* **Chores**
  * Enabled secure identity token permissions for benchmark reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->